### PR TITLE
Feature: get GPU information

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -90,3 +90,6 @@ find .devcontainer/ -type f -name devcontainer.json -print0 | while IFS= read -r
     sed_runner "s@rapidsai/devcontainers/features/rapids-build-utils:[0-9.]*@rapidsai/devcontainers/features/rapids-build-utils:${NEXT_SHORT_TAG_PEP440}@" "${filename}"
     sed_runner "s@rapids-\${localWorkspaceFolderBasename}-${CURRENT_SHORT_TAG}@rapids-\${localWorkspaceFolderBasename}-${NEXT_SHORT_TAG}@g" "${filename}"
 done
+
+# Update Java API version
+sed_runner "s/VERSION=\".*\"/VERSION=\"${NEXT_FULL_TAG}\"/g" java/build.sh

--- a/java/build.sh
+++ b/java/build.sh
@@ -1,4 +1,4 @@
-VERSION="25.02"
+VERSION="25.02" # Note: The version is upated automatically when ci/release/update-version.sh is invoked
 GROUP_ID="com.nvidia.cuvs"
 SO_FILE_PATH="./internal"
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/BruteForceIndex.java
@@ -32,7 +32,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.UUID;
 
 import com.nvidia.cuvs.common.Util;
-import com.nvidia.cuvs.panama.cuvsBruteForceIndex;
+import com.nvidia.cuvs.panama.CuVSBruteForceIndex;
 
 /**
  * 
@@ -338,7 +338,7 @@ public class BruteForceIndex {
      * Constructs CagraIndexReference and allocate the MemorySegment.
      */
     protected IndexReference(CuVSResources resources) {
-      memorySegment = cuvsBruteForceIndex.allocate(resources.arena);
+      memorySegment = CuVSBruteForceIndex.allocate(resources.arena);
     }
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraCompressionParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraCompressionParams.java
@@ -18,7 +18,7 @@ package com.nvidia.cuvs;
 
 import java.lang.foreign.MemorySegment;
 
-import com.nvidia.cuvs.panama.CuvsCagraCompressionParams;
+import com.nvidia.cuvs.panama.CuVSCagraCompressionParams;
 
 /**
  * Supplemental compression parameters to build CAGRA Index.
@@ -70,13 +70,13 @@ public class CagraCompressionParams {
    * Allocates the configured compression parameters in the MemorySegment.
    */
   private MemorySegment initMemorySegment() {
-    MemorySegment compressionParamsMemorySegment = CuvsCagraCompressionParams.allocate(resources.arena);
-    CuvsCagraCompressionParams.pq_bits(compressionParamsMemorySegment, pqBits);
-    CuvsCagraCompressionParams.pq_dim(compressionParamsMemorySegment, pqDim);
-    CuvsCagraCompressionParams.vq_n_centers(compressionParamsMemorySegment, vqNCenters);
-    CuvsCagraCompressionParams.kmeans_n_iters(compressionParamsMemorySegment, kmeansNIters);
-    CuvsCagraCompressionParams.vq_kmeans_trainset_fraction(compressionParamsMemorySegment, vqKmeansTrainsetFraction);
-    CuvsCagraCompressionParams.pq_kmeans_trainset_fraction(compressionParamsMemorySegment, pqKmeansTrainsetFraction);
+    MemorySegment compressionParamsMemorySegment = CuVSCagraCompressionParams.allocate(resources.arena);
+    CuVSCagraCompressionParams.pq_bits(compressionParamsMemorySegment, pqBits);
+    CuVSCagraCompressionParams.pq_dim(compressionParamsMemorySegment, pqDim);
+    CuVSCagraCompressionParams.vq_n_centers(compressionParamsMemorySegment, vqNCenters);
+    CuVSCagraCompressionParams.kmeans_n_iters(compressionParamsMemorySegment, kmeansNIters);
+    CuVSCagraCompressionParams.vq_kmeans_trainset_fraction(compressionParamsMemorySegment, vqKmeansTrainsetFraction);
+    CuVSCagraCompressionParams.pq_kmeans_trainset_fraction(compressionParamsMemorySegment, pqKmeansTrainsetFraction);
     return compressionParamsMemorySegment;
   }
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraIndex.java
@@ -32,7 +32,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.UUID;
 
 import com.nvidia.cuvs.common.Util;
-import com.nvidia.cuvs.panama.cuvsCagraIndex;
+import com.nvidia.cuvs.panama.CuVSCagraIndex;
 
 /**
  * {@link CagraIndex} encapsulates a CAGRA index, along with methods to interact
@@ -491,7 +491,7 @@ public class CagraIndex {
      * Constructs CagraIndexReference and allocate the MemorySegment.
      */
     protected IndexReference(CuVSResources resources) {
-      memorySegment = cuvsCagraIndex.allocate(resources.arena);
+      memorySegment = CuVSCagraIndex.allocate(resources.arena);
     }
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraSearchParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraSearchParams.java
@@ -18,7 +18,7 @@ package com.nvidia.cuvs;
 
 import java.lang.foreign.MemorySegment;
 
-import com.nvidia.cuvs.panama.CuvsCagraSearchParams;
+import com.nvidia.cuvs.panama.CuVSCagraSearchParams;
 
 /**
  * CagraSearchParams encapsulates the logic for configuring and holding search
@@ -152,24 +152,24 @@ public class CagraSearchParams {
    * Allocates the configured search parameters in the MemorySegment.
    */
   private MemorySegment allocateMemorySegment() {
-    MemorySegment memorySegment = CuvsCagraSearchParams.allocate(resources.arena);
-    CuvsCagraSearchParams.max_queries(memorySegment, maxQueries);
-    CuvsCagraSearchParams.itopk_size(memorySegment, iTopKSize);
-    CuvsCagraSearchParams.max_iterations(memorySegment, maxIterations);
+    MemorySegment memorySegment = CuVSCagraSearchParams.allocate(resources.arena);
+    CuVSCagraSearchParams.max_queries(memorySegment, maxQueries);
+    CuVSCagraSearchParams.itopk_size(memorySegment, iTopKSize);
+    CuVSCagraSearchParams.max_iterations(memorySegment, maxIterations);
     if (searchAlgo != null) {
-      CuvsCagraSearchParams.algo(memorySegment, searchAlgo.value);
+      CuVSCagraSearchParams.algo(memorySegment, searchAlgo.value);
     }
-    CuvsCagraSearchParams.team_size(memorySegment, teamSize);
-    CuvsCagraSearchParams.search_width(memorySegment, searchWidth);
-    CuvsCagraSearchParams.min_iterations(memorySegment, minIterations);
-    CuvsCagraSearchParams.thread_block_size(memorySegment, threadBlockSize);
+    CuVSCagraSearchParams.team_size(memorySegment, teamSize);
+    CuVSCagraSearchParams.search_width(memorySegment, searchWidth);
+    CuVSCagraSearchParams.min_iterations(memorySegment, minIterations);
+    CuVSCagraSearchParams.thread_block_size(memorySegment, threadBlockSize);
     if (hashMapMode != null) {
-      CuvsCagraSearchParams.hashmap_mode(memorySegment, hashMapMode.value);
+      CuVSCagraSearchParams.hashmap_mode(memorySegment, hashMapMode.value);
     }
-    CuvsCagraSearchParams.hashmap_min_bitlen(memorySegment, hashmapMinBitlen);
-    CuvsCagraSearchParams.hashmap_max_fill_rate(memorySegment, hashMapMaxFillRate);
-    CuvsCagraSearchParams.num_random_samplings(memorySegment, numRandomSamplings);
-    CuvsCagraSearchParams.rand_xor_mask(memorySegment, randXORMask);
+    CuVSCagraSearchParams.hashmap_min_bitlen(memorySegment, hashmapMinBitlen);
+    CuVSCagraSearchParams.hashmap_max_fill_rate(memorySegment, hashMapMaxFillRate);
+    CuVSCagraSearchParams.num_random_samplings(memorySegment, numRandomSamplings);
+    CuVSCagraSearchParams.rand_xor_mask(memorySegment, randXORMask);
     return memorySegment;
   }
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
@@ -21,10 +21,15 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.nvidia.cuvs.common.Util;
 
@@ -41,8 +46,11 @@ public class CuVSResources implements AutoCloseable {
   protected File nativeLibrary;
   private final MethodHandle createResourcesMethodHandle;
   private final MethodHandle destroyResourcesMethodHandle;
+  private final MethodHandle getGpuInfoMethodHandle;
+  private final MethodHandle getNumGpusMethodHandle;
   private MemorySegment resourcesMemorySegment;
   private MemoryLayout intMemoryLayout;
+  private MemoryLayout longMemoryLayout;
 
   /**
    * Constructor that allocates the resources needed for cuVS
@@ -56,6 +64,7 @@ public class CuVSResources implements AutoCloseable {
     nativeLibrary = Util.loadLibraryFromJar("/libcuvs_java.so");
     symbolLookup = SymbolLookup.libraryLookup(nativeLibrary.getAbsolutePath(), arena);
     intMemoryLayout = linker.canonicalLayouts().get("int");
+    longMemoryLayout = linker.canonicalLayouts().get("long");
 
     createResourcesMethodHandle = linker.downcallHandle(symbolLookup.find("create_resources").get(),
         FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
@@ -63,7 +72,80 @@ public class CuVSResources implements AutoCloseable {
     destroyResourcesMethodHandle = linker.downcallHandle(symbolLookup.find("destroy_resources").get(),
         FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
+    getNumGpusMethodHandle = linker.downcallHandle(symbolLookup.find("get_num_gpus").get(),
+        FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+    getGpuInfoMethodHandle = linker.downcallHandle(symbolLookup.find("get_gpu_info").get(), FunctionDescriptor
+        .ofVoid(ValueLayout.ADDRESS, intMemoryLayout, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+    getNumGPUs();
     createResources();
+  }
+
+  /**
+   * Gets the number of GPUs on the machine
+   * 
+   * @return the number of GPUs on the machine
+   */
+  public int getNumGPUs() throws Throwable {
+    MemoryLayout returnValueMemoryLayout = intMemoryLayout;
+    MemorySegment returnValueMemorySegment = arena.allocate(returnValueMemoryLayout);
+
+    MemoryLayout numGPUsMemoryLayout = intMemoryLayout;
+    MemorySegment numGPUsMemorySegment = arena.allocate(numGPUsMemoryLayout);
+
+    getNumGpusMethodHandle.invokeExact(returnValueMemorySegment, numGPUsMemorySegment);
+    int returnValue = returnValueMemorySegment.get(ValueLayout.JAVA_INT, 0);
+
+    switch (returnValue) {
+    case 0: // cudaSuccess
+      return numGPUsMemorySegment.get(ValueLayout.JAVA_INT, 0);
+    case 3: // cudaErrorInitializationError
+      throw new GPUException("The API call failed because the CUDA driver and runtime could not be initialized.");
+    case 35: // cudaErrorInsufficientDriver
+      throw new GPUException("The installed NVIDIA CUDA driver is older than the CUDA runtime library");
+    case 100: // cudaErrorNoDevice
+      throw new GPUException("No CUDA-capable devices were detected by the installed CUDA driver");
+    default:
+      throw new GPUException("Return value: " + returnValue
+          + " Please find details here: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3f51e3575c2178246db0a94a430e0038");
+    }
+  }
+
+  /**
+   * Gets the GPU information
+   * 
+   */
+  public List<GPUInfo> getGPUInfo() throws Throwable {
+    int numGPUs = getNumGPUs();
+    List<GPUInfo> results = new ArrayList<GPUInfo>();
+    MemoryLayout returnValueMemoryLayout = intMemoryLayout;
+    MemorySegment returnValueMemorySegment = arena.allocate(returnValueMemoryLayout);
+
+    SequenceLayout gpuIdSequenceLayout = MemoryLayout.sequenceLayout(numGPUs, intMemoryLayout);
+    MemorySegment gpuIdMemorySegment = arena.allocate(gpuIdSequenceLayout);
+
+    SequenceLayout freeMemSequenceLayout = MemoryLayout.sequenceLayout(numGPUs, longMemoryLayout);
+    MemorySegment freeMemMemorySegment = arena.allocate(freeMemSequenceLayout);
+
+    SequenceLayout totalMemSequenceLayout = MemoryLayout.sequenceLayout(numGPUs, longMemoryLayout);
+    MemorySegment totalMemMemorySegment = arena.allocate(totalMemSequenceLayout);
+
+    getGpuInfoMethodHandle.invokeExact(returnValueMemorySegment, numGPUs, gpuIdMemorySegment, freeMemMemorySegment,
+        totalMemMemorySegment);
+
+    VarHandle gpuIdVarHandle = gpuIdSequenceLayout.varHandle(PathElement.sequenceElement());
+    VarHandle freeMemVarHandle = freeMemSequenceLayout.varHandle(PathElement.sequenceElement());
+    VarHandle totalMemVarHandle = totalMemSequenceLayout.varHandle(PathElement.sequenceElement());
+
+    for (int i = 0; i < numGPUs; i++) {
+      int id = (int) gpuIdVarHandle.get(gpuIdMemorySegment, 0L, i);
+      long freeMem = (long) freeMemVarHandle.get(freeMemMemorySegment, 0L, i);
+      long totalMem = (long) totalMemVarHandle.get(totalMemMemorySegment, 0L, i);
+      results.add(new GPUInfo(id, freeMem, totalMem));
+    }
+
+    return results;
   }
 
   /**
@@ -105,4 +187,37 @@ public class CuVSResources implements AutoCloseable {
     return symbolLookup;
   }
 
+  /**
+   * Container for GPU information
+   */
+  public class GPUInfo {
+
+    private int gpuId;
+    private long freeMemory;
+    private long totalMemory;
+
+    public GPUInfo(int gpuId, long freeMemory, long totalMemory) {
+      super();
+      this.gpuId = gpuId;
+      this.freeMemory = freeMemory;
+      this.totalMemory = totalMemory;
+    }
+
+    public int getGpuId() {
+      return gpuId;
+    }
+
+    public long getFreeMemory() {
+      return freeMemory;
+    }
+
+    public long getTotalMemory() {
+      return totalMemory;
+    }
+
+    @Override
+    public String toString() {
+      return "GPUInfo [gpuId=" + gpuId + ", freeMemory=" + freeMemory + ", totalMemory=" + totalMemory + "]";
+    }
+  }
 }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
@@ -78,7 +78,9 @@ public class CuVSResources implements AutoCloseable {
     getGpuInfoMethodHandle = linker.downcallHandle(symbolLookup.find("get_gpu_info").get(), FunctionDescriptor
         .ofVoid(ValueLayout.ADDRESS, intMemoryLayout, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
-    getNumGPUs();
+    if (getNumGPUs() == 0)
+      throw new GPUException("No GPUs found! The CuVS Java API needs GPU to work.");
+
     createResources();
   }
 
@@ -115,6 +117,7 @@ public class CuVSResources implements AutoCloseable {
   /**
    * Gets the GPU information
    * 
+   * @return a list of {@link GPUInfo} objects with GPU details
    */
   public List<GPUInfo> getGPUInfo() throws Throwable {
     int numGPUs = getNumGPUs();
@@ -139,10 +142,10 @@ public class CuVSResources implements AutoCloseable {
     VarHandle totalMemVarHandle = totalMemSequenceLayout.varHandle(PathElement.sequenceElement());
 
     for (int i = 0; i < numGPUs; i++) {
-      int id = (int) gpuIdVarHandle.get(gpuIdMemorySegment, 0L, i);
-      long freeMem = (long) freeMemVarHandle.get(freeMemMemorySegment, 0L, i);
-      long totalMem = (long) totalMemVarHandle.get(totalMemMemorySegment, 0L, i);
-      results.add(new GPUInfo(id, freeMem, totalMem));
+      int gpuId = (int) gpuIdVarHandle.get(gpuIdMemorySegment, 0L, i);
+      long freeMemory = (long) freeMemVarHandle.get(freeMemMemorySegment, 0L, i);
+      long totalMemory = (long) totalMemVarHandle.get(totalMemMemorySegment, 0L, i);
+      results.add(new GPUInfo(gpuId, freeMemory, totalMemory));
     }
 
     return results;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/GPUException.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/GPUException.java
@@ -1,0 +1,14 @@
+package com.nvidia.cuvs;
+
+public class GPUException extends RuntimeException {
+
+  private static final long serialVersionUID = 3634160877601102571L;
+
+  public GPUException(Exception ex) {
+    super(ex);
+  }
+
+  public GPUException(String message) {
+    super(message);
+  }
+}

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswIndex.java
@@ -30,7 +30,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.UUID;
 
 import com.nvidia.cuvs.common.Util;
-import com.nvidia.cuvs.panama.CuvsHnswIndex;
+import com.nvidia.cuvs.panama.CuVSHnswIndex;
 
 /**
  * {@link HnswIndex} encapsulates a HNSW index, along with methods to interact
@@ -237,7 +237,7 @@ public class HnswIndex {
      * Constructs CagraIndexReference and allocate the MemorySegment.
      */
     protected IndexReference(CuVSResources resources) {
-      memorySegment = CuvsHnswIndex.allocate(resources.arena);
+      memorySegment = CuVSHnswIndex.allocate(resources.arena);
     }
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswIndexParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswIndexParams.java
@@ -18,7 +18,7 @@ package com.nvidia.cuvs;
 
 import java.lang.foreign.MemorySegment;
 
-import com.nvidia.cuvs.panama.CuvsHnswIndexParams;
+import com.nvidia.cuvs.panama.CuVSHnswIndexParams;
 
 /**
  * Supplemental parameters to build HNSW index.
@@ -76,9 +76,9 @@ public class HnswIndexParams {
    * Allocates the configured search parameters in the MemorySegment.
    */
   private MemorySegment allocateMemorySegment() {
-    MemorySegment memorySegment = CuvsHnswIndexParams.allocate(resources.arena);
-    CuvsHnswIndexParams.ef_construction(memorySegment, efConstruction);
-    CuvsHnswIndexParams.num_threads(memorySegment, numThreads);
+    MemorySegment memorySegment = CuVSHnswIndexParams.allocate(resources.arena);
+    CuVSHnswIndexParams.ef_construction(memorySegment, efConstruction);
+    CuVSHnswIndexParams.num_threads(memorySegment, numThreads);
     return memorySegment;
   }
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswSearchParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswSearchParams.java
@@ -18,7 +18,7 @@ package com.nvidia.cuvs;
 
 import java.lang.foreign.MemorySegment;
 
-import com.nvidia.cuvs.panama.CuvsHnswSearchParams;
+import com.nvidia.cuvs.panama.CuVSHnswSearchParams;
 
 /**
  * HnswSearchParams encapsulates the logic for configuring and holding search
@@ -52,9 +52,9 @@ public class HnswSearchParams {
    * Allocates the configured search parameters in the MemorySegment.
    */
   private MemorySegment allocateMemorySegment() {
-    MemorySegment memorySegment = CuvsHnswSearchParams.allocate(resources.arena);
-    CuvsHnswSearchParams.ef(memorySegment, ef);
-    CuvsHnswSearchParams.num_threads(memorySegment, numThreads);
+    MemorySegment memorySegment = CuVSHnswSearchParams.allocate(resources.arena);
+    CuVSHnswSearchParams.ef(memorySegment, ef);
+    CuVSHnswSearchParams.num_threads(memorySegment, numThreads);
     return memorySegment;
   }
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/BruteForceH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/BruteForceH.java
@@ -39,9 +39,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class hnsw_h {
+public class BruteForceH {
 
-  hnsw_h() {
+  BruteForceH() {
     // Should not be called directly
   }
 
@@ -640,711 +640,471 @@ public class hnsw_h {
     return _BITS_STDINT_UINTN_H;
   }
 
-  private static final int true_ = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * #define true 1
-   * }
-   */
-  public static int true_() {
-    return true_;
-  }
-
-  private static final int false_ = (int) 0L;
-
-  /**
-   * {@snippet lang = c : * #define false 0
-   * }
-   */
-  public static int false_() {
-    return false_;
-  }
-
-  private static final int __bool_true_false_are_defined = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * #define __bool_true_false_are_defined 1
-   * }
-   */
-  public static int __bool_true_false_are_defined() {
-    return __bool_true_false_are_defined;
-  }
-
-  private static final int L2Expanded = (int) 0L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.L2Expanded = 0
-   * }
-   */
-  public static int L2Expanded() {
-    return L2Expanded;
-  }
-
-  private static final int L2SqrtExpanded = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.L2SqrtExpanded = 1
-   * }
-   */
-  public static int L2SqrtExpanded() {
-    return L2SqrtExpanded;
-  }
-
-  private static final int CosineExpanded = (int) 2L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.CosineExpanded = 2
-   * }
-   */
-  public static int CosineExpanded() {
-    return CosineExpanded;
-  }
-
-  private static final int L1 = (int) 3L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.L1 = 3
-   * }
-   */
-  public static int L1() {
-    return L1;
-  }
-
-  private static final int L2Unexpanded = (int) 4L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.L2Unexpanded = 4
-   * }
-   */
-  public static int L2Unexpanded() {
-    return L2Unexpanded;
-  }
-
-  private static final int L2SqrtUnexpanded = (int) 5L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.L2SqrtUnexpanded = 5
-   * }
-   */
-  public static int L2SqrtUnexpanded() {
-    return L2SqrtUnexpanded;
-  }
-
-  private static final int InnerProduct = (int) 6L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.InnerProduct = 6
-   * }
-   */
-  public static int InnerProduct() {
-    return InnerProduct;
-  }
-
-  private static final int Linf = (int) 7L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.Linf = 7
-   * }
-   */
-  public static int Linf() {
-    return Linf;
-  }
-
-  private static final int Canberra = (int) 8L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.Canberra = 8
-   * }
-   */
-  public static int Canberra() {
-    return Canberra;
-  }
-
-  private static final int LpUnexpanded = (int) 9L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.LpUnexpanded = 9
-   * }
-   */
-  public static int LpUnexpanded() {
-    return LpUnexpanded;
-  }
-
-  private static final int CorrelationExpanded = (int) 10L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.CorrelationExpanded = 10
-   * }
-   */
-  public static int CorrelationExpanded() {
-    return CorrelationExpanded;
-  }
-
-  private static final int JaccardExpanded = (int) 11L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.JaccardExpanded = 11
-   * }
-   */
-  public static int JaccardExpanded() {
-    return JaccardExpanded;
-  }
-
-  private static final int HellingerExpanded = (int) 12L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.HellingerExpanded = 12
-   * }
-   */
-  public static int HellingerExpanded() {
-    return HellingerExpanded;
-  }
-
-  private static final int Haversine = (int) 13L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.Haversine = 13
-   * }
-   */
-  public static int Haversine() {
-    return Haversine;
-  }
-
-  private static final int BrayCurtis = (int) 14L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.BrayCurtis = 14
-   * }
-   */
-  public static int BrayCurtis() {
-    return BrayCurtis;
-  }
-
-  private static final int JensenShannon = (int) 15L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.JensenShannon = 15
-   * }
-   */
-  public static int JensenShannon() {
-    return JensenShannon;
-  }
-
-  private static final int HammingUnexpanded = (int) 16L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.HammingUnexpanded = 16
-   * }
-   */
-  public static int HammingUnexpanded() {
-    return HammingUnexpanded;
-  }
-
-  private static final int KLDivergence = (int) 17L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.KLDivergence = 17
-   * }
-   */
-  public static int KLDivergence() {
-    return KLDivergence;
-  }
-
-  private static final int RusselRaoExpanded = (int) 18L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.RusselRaoExpanded = 18
-   * }
-   */
-  public static int RusselRaoExpanded() {
-    return RusselRaoExpanded;
-  }
-
-  private static final int DiceExpanded = (int) 19L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.DiceExpanded = 19
-   * }
-   */
-  public static int DiceExpanded() {
-    return DiceExpanded;
-  }
-
-  private static final int Precomputed = (int) 100L;
-
-  /**
-   * {@snippet lang = c : * enum <anonymous>.Precomputed = 100
-   * }
-   */
-  public static int Precomputed() {
-    return Precomputed;
-  }
-
   /**
    * {@snippet lang = c : * typedef unsigned char __u_char
    * }
    */
-  public static final OfByte __u_char = hnsw_h.C_CHAR;
+  public static final OfByte __u_char = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned short __u_short
    * }
    */
-  public static final OfShort __u_short = hnsw_h.C_SHORT;
+  public static final OfShort __u_short = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned int __u_int
    * }
    */
-  public static final OfInt __u_int = hnsw_h.C_INT;
+  public static final OfInt __u_int = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_long
    * }
    */
-  public static final OfLong __u_long = hnsw_h.C_LONG;
+  public static final OfLong __u_long = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char __int8_t
    * }
    */
-  public static final OfByte __int8_t = hnsw_h.C_CHAR;
+  public static final OfByte __int8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned char __uint8_t
    * }
    */
-  public static final OfByte __uint8_t = hnsw_h.C_CHAR;
+  public static final OfByte __uint8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef short __int16_t
    * }
    */
-  public static final OfShort __int16_t = hnsw_h.C_SHORT;
+  public static final OfShort __int16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned short __uint16_t
    * }
    */
-  public static final OfShort __uint16_t = hnsw_h.C_SHORT;
+  public static final OfShort __uint16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef int __int32_t
    * }
    */
-  public static final OfInt __int32_t = hnsw_h.C_INT;
+  public static final OfInt __int32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __uint32_t
    * }
    */
-  public static final OfInt __uint32_t = hnsw_h.C_INT;
+  public static final OfInt __uint32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __int64_t
    * }
    */
-  public static final OfLong __int64_t = hnsw_h.C_LONG;
+  public static final OfLong __int64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uint64_t
    * }
    */
-  public static final OfLong __uint64_t = hnsw_h.C_LONG;
+  public static final OfLong __uint64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int8_t __int_least8_t
    * }
    */
-  public static final OfByte __int_least8_t = hnsw_h.C_CHAR;
+  public static final OfByte __int_least8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint8_t __uint_least8_t
    * }
    */
-  public static final OfByte __uint_least8_t = hnsw_h.C_CHAR;
+  public static final OfByte __uint_least8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t __int_least16_t
    * }
    */
-  public static final OfShort __int_least16_t = hnsw_h.C_SHORT;
+  public static final OfShort __int_least16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint16_t __uint_least16_t
    * }
    */
-  public static final OfShort __uint_least16_t = hnsw_h.C_SHORT;
+  public static final OfShort __uint_least16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t __int_least32_t
    * }
    */
-  public static final OfInt __int_least32_t = hnsw_h.C_INT;
+  public static final OfInt __int_least32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint32_t __uint_least32_t
    * }
    */
-  public static final OfInt __uint_least32_t = hnsw_h.C_INT;
+  public static final OfInt __uint_least32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t __int_least64_t
    * }
    */
-  public static final OfLong __int_least64_t = hnsw_h.C_LONG;
+  public static final OfLong __int_least64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint64_t __uint_least64_t
    * }
    */
-  public static final OfLong __uint_least64_t = hnsw_h.C_LONG;
+  public static final OfLong __uint_least64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __quad_t
    * }
    */
-  public static final OfLong __quad_t = hnsw_h.C_LONG;
+  public static final OfLong __quad_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_quad_t
    * }
    */
-  public static final OfLong __u_quad_t = hnsw_h.C_LONG;
+  public static final OfLong __u_quad_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __intmax_t
    * }
    */
-  public static final OfLong __intmax_t = hnsw_h.C_LONG;
+  public static final OfLong __intmax_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uintmax_t
    * }
    */
-  public static final OfLong __uintmax_t = hnsw_h.C_LONG;
+  public static final OfLong __uintmax_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __dev_t
    * }
    */
-  public static final OfLong __dev_t = hnsw_h.C_LONG;
+  public static final OfLong __dev_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __uid_t
    * }
    */
-  public static final OfInt __uid_t = hnsw_h.C_INT;
+  public static final OfInt __uid_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __gid_t
    * }
    */
-  public static final OfInt __gid_t = hnsw_h.C_INT;
+  public static final OfInt __gid_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino_t
    * }
    */
-  public static final OfLong __ino_t = hnsw_h.C_LONG;
+  public static final OfLong __ino_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino64_t
    * }
    */
-  public static final OfLong __ino64_t = hnsw_h.C_LONG;
+  public static final OfLong __ino64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __mode_t
    * }
    */
-  public static final OfInt __mode_t = hnsw_h.C_INT;
+  public static final OfInt __mode_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __nlink_t
    * }
    */
-  public static final OfLong __nlink_t = hnsw_h.C_LONG;
+  public static final OfLong __nlink_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off_t
    * }
    */
-  public static final OfLong __off_t = hnsw_h.C_LONG;
+  public static final OfLong __off_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off64_t
    * }
    */
-  public static final OfLong __off64_t = hnsw_h.C_LONG;
+  public static final OfLong __off64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __pid_t
    * }
    */
-  public static final OfInt __pid_t = hnsw_h.C_INT;
+  public static final OfInt __pid_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __clock_t
    * }
    */
-  public static final OfLong __clock_t = hnsw_h.C_LONG;
+  public static final OfLong __clock_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim_t
    * }
    */
-  public static final OfLong __rlim_t = hnsw_h.C_LONG;
+  public static final OfLong __rlim_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim64_t
    * }
    */
-  public static final OfLong __rlim64_t = hnsw_h.C_LONG;
+  public static final OfLong __rlim64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __id_t
    * }
    */
-  public static final OfInt __id_t = hnsw_h.C_INT;
+  public static final OfInt __id_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __time_t
    * }
    */
-  public static final OfLong __time_t = hnsw_h.C_LONG;
+  public static final OfLong __time_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __useconds_t
    * }
    */
-  public static final OfInt __useconds_t = hnsw_h.C_INT;
+  public static final OfInt __useconds_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __suseconds_t
    * }
    */
-  public static final OfLong __suseconds_t = hnsw_h.C_LONG;
+  public static final OfLong __suseconds_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __suseconds64_t
    * }
    */
-  public static final OfLong __suseconds64_t = hnsw_h.C_LONG;
+  public static final OfLong __suseconds64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __daddr_t
    * }
    */
-  public static final OfInt __daddr_t = hnsw_h.C_INT;
+  public static final OfInt __daddr_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __key_t
    * }
    */
-  public static final OfInt __key_t = hnsw_h.C_INT;
+  public static final OfInt __key_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __clockid_t
    * }
    */
-  public static final OfInt __clockid_t = hnsw_h.C_INT;
+  public static final OfInt __clockid_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef void *__timer_t
    * }
    */
-  public static final AddressLayout __timer_t = hnsw_h.C_POINTER;
+  public static final AddressLayout __timer_t = BruteForceH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __blksize_t
    * }
    */
-  public static final OfLong __blksize_t = hnsw_h.C_LONG;
+  public static final OfLong __blksize_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt_t
    * }
    */
-  public static final OfLong __blkcnt_t = hnsw_h.C_LONG;
+  public static final OfLong __blkcnt_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt64_t
    * }
    */
-  public static final OfLong __blkcnt64_t = hnsw_h.C_LONG;
+  public static final OfLong __blkcnt64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt_t
    * }
    */
-  public static final OfLong __fsblkcnt_t = hnsw_h.C_LONG;
+  public static final OfLong __fsblkcnt_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt64_t
    * }
    */
-  public static final OfLong __fsblkcnt64_t = hnsw_h.C_LONG;
+  public static final OfLong __fsblkcnt64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt_t
    * }
    */
-  public static final OfLong __fsfilcnt_t = hnsw_h.C_LONG;
+  public static final OfLong __fsfilcnt_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt64_t
    * }
    */
-  public static final OfLong __fsfilcnt64_t = hnsw_h.C_LONG;
+  public static final OfLong __fsfilcnt64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __fsword_t
    * }
    */
-  public static final OfLong __fsword_t = hnsw_h.C_LONG;
+  public static final OfLong __fsword_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __ssize_t
    * }
    */
-  public static final OfLong __ssize_t = hnsw_h.C_LONG;
+  public static final OfLong __ssize_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __syscall_slong_t
    * }
    */
-  public static final OfLong __syscall_slong_t = hnsw_h.C_LONG;
+  public static final OfLong __syscall_slong_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __syscall_ulong_t
    * }
    */
-  public static final OfLong __syscall_ulong_t = hnsw_h.C_LONG;
+  public static final OfLong __syscall_ulong_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __off64_t __loff_t
    * }
    */
-  public static final OfLong __loff_t = hnsw_h.C_LONG;
+  public static final OfLong __loff_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef char *__caddr_t
    * }
    */
-  public static final AddressLayout __caddr_t = hnsw_h.C_POINTER;
+  public static final AddressLayout __caddr_t = BruteForceH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __intptr_t
    * }
    */
-  public static final OfLong __intptr_t = hnsw_h.C_LONG;
+  public static final OfLong __intptr_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __socklen_t
    * }
    */
-  public static final OfInt __socklen_t = hnsw_h.C_INT;
+  public static final OfInt __socklen_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __sig_atomic_t
    * }
    */
-  public static final OfInt __sig_atomic_t = hnsw_h.C_INT;
+  public static final OfInt __sig_atomic_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int8_t int8_t
    * }
    */
-  public static final OfByte int8_t = hnsw_h.C_CHAR;
+  public static final OfByte int8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t int16_t
    * }
    */
-  public static final OfShort int16_t = hnsw_h.C_SHORT;
+  public static final OfShort int16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t int32_t
    * }
    */
-  public static final OfInt int32_t = hnsw_h.C_INT;
+  public static final OfInt int32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t int64_t
    * }
    */
-  public static final OfLong int64_t = hnsw_h.C_LONG;
+  public static final OfLong int64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint8_t uint8_t
    * }
    */
-  public static final OfByte uint8_t = hnsw_h.C_CHAR;
+  public static final OfByte uint8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint16_t uint16_t
    * }
    */
-  public static final OfShort uint16_t = hnsw_h.C_SHORT;
+  public static final OfShort uint16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint32_t uint32_t
    * }
    */
-  public static final OfInt uint32_t = hnsw_h.C_INT;
+  public static final OfInt uint32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint64_t uint64_t
    * }
    */
-  public static final OfLong uint64_t = hnsw_h.C_LONG;
+  public static final OfLong uint64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int_least8_t int_least8_t
    * }
    */
-  public static final OfByte int_least8_t = hnsw_h.C_CHAR;
+  public static final OfByte int_least8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int_least16_t int_least16_t
    * }
    */
-  public static final OfShort int_least16_t = hnsw_h.C_SHORT;
+  public static final OfShort int_least16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int_least32_t int_least32_t
    * }
    */
-  public static final OfInt int_least32_t = hnsw_h.C_INT;
+  public static final OfInt int_least32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int_least64_t int_least64_t
    * }
    */
-  public static final OfLong int_least64_t = hnsw_h.C_LONG;
+  public static final OfLong int_least64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint_least8_t uint_least8_t
    * }
    */
-  public static final OfByte uint_least8_t = hnsw_h.C_CHAR;
+  public static final OfByte uint_least8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint_least16_t uint_least16_t
    * }
    */
-  public static final OfShort uint_least16_t = hnsw_h.C_SHORT;
+  public static final OfShort uint_least16_t = BruteForceH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint_least32_t uint_least32_t
    * }
    */
-  public static final OfInt uint_least32_t = hnsw_h.C_INT;
+  public static final OfInt uint_least32_t = BruteForceH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint_least64_t uint_least64_t
    * }
    */
-  public static final OfLong uint_least64_t = hnsw_h.C_LONG;
+  public static final OfLong uint_least64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char int_fast8_t
    * }
    */
-  public static final OfByte int_fast8_t = hnsw_h.C_CHAR;
+  public static final OfByte int_fast8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef long int_fast16_t
    * }
    */
-  public static final OfLong int_fast16_t = hnsw_h.C_LONG;
+  public static final OfLong int_fast16_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast32_t
    * }
    */
-  public static final OfLong int_fast32_t = hnsw_h.C_LONG;
+  public static final OfLong int_fast32_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast64_t
    * }
    */
-  public static final OfLong int_fast64_t = hnsw_h.C_LONG;
+  public static final OfLong int_fast64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned char uint_fast8_t
    * }
    */
-  public static final OfByte uint_fast8_t = hnsw_h.C_CHAR;
+  public static final OfByte uint_fast8_t = BruteForceH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast16_t
    * }
    */
-  public static final OfLong uint_fast16_t = hnsw_h.C_LONG;
+  public static final OfLong uint_fast16_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast32_t
    * }
    */
-  public static final OfLong uint_fast32_t = hnsw_h.C_LONG;
+  public static final OfLong uint_fast32_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast64_t
    * }
    */
-  public static final OfLong uint_fast64_t = hnsw_h.C_LONG;
+  public static final OfLong uint_fast64_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long intptr_t
    * }
    */
-  public static final OfLong intptr_t = hnsw_h.C_LONG;
+  public static final OfLong intptr_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uintptr_t
    * }
    */
-  public static final OfLong uintptr_t = hnsw_h.C_LONG;
+  public static final OfLong uintptr_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __intmax_t intmax_t
    * }
    */
-  public static final OfLong intmax_t = hnsw_h.C_LONG;
+  public static final OfLong intmax_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uintmax_t uintmax_t
    * }
    */
-  public static final OfLong uintmax_t = hnsw_h.C_LONG;
+  public static final OfLong uintmax_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long ptrdiff_t
    * }
    */
-  public static final OfLong ptrdiff_t = hnsw_h.C_LONG;
+  public static final OfLong ptrdiff_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long size_t
    * }
    */
-  public static final OfLong size_t = hnsw_h.C_LONG;
+  public static final OfLong size_t = BruteForceH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int wchar_t
    * }
    */
-  public static final OfInt wchar_t = hnsw_h.C_INT;
+  public static final OfInt wchar_t = BruteForceH.C_INT;
   private static final int kDLCPU = (int) 1L;
 
   /**
@@ -1555,209 +1315,11 @@ public class hnsw_h {
     return kDLBool;
   }
 
-  private static final int AUTO_SELECT = (int) 0L;
-
   /**
-   * {@snippet lang = c : * enum cuvsCagraGraphBuildAlgo.AUTO_SELECT = 0
+   * {@snippet lang = c : * typedef cuvsBruteForceIndex *cuvsBruteForceIndex_t
    * }
    */
-  public static int AUTO_SELECT() {
-    return AUTO_SELECT;
-  }
-
-  private static final int IVF_PQ = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraGraphBuildAlgo.IVF_PQ = 1
-   * }
-   */
-  public static int IVF_PQ() {
-    return IVF_PQ;
-  }
-
-  private static final int NN_DESCENT = (int) 2L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraGraphBuildAlgo.NN_DESCENT = 2
-   * }
-   */
-  public static int NN_DESCENT() {
-    return NN_DESCENT;
-  }
-
-  /**
-   * {@snippet lang = c :
-   * typedef struct cuvsCagraCompressionParams {
-   *     uint32_t pq_bits;
-   *     uint32_t pq_dim;
-   *     uint32_t vq_n_centers;
-   *     uint32_t kmeans_n_iters;
-   *     double vq_kmeans_trainset_fraction;
-   *     double pq_kmeans_trainset_fraction;
-   * } *cuvsCagraCompressionParams_t
-   * }
-   */
-  public static final AddressLayout cuvsCagraCompressionParams_t = hnsw_h.C_POINTER;
-  /**
-   * {@snippet lang = c :
-   * typedef struct cuvsCagraIndexParams {
-   *     cuvsDistanceType metric;
-   *     long intermediate_graph_degree;
-   *     long graph_degree;
-   *     enum cuvsCagraGraphBuildAlgo build_algo;
-   *     long nn_descent_niter;
-   *     cuvsCagraCompressionParams_t compression;
-   * } *cuvsCagraIndexParams_t
-   * }
-   */
-  public static final AddressLayout cuvsCagraIndexParams_t = hnsw_h.C_POINTER;
-  private static final int SINGLE_CTA = (int) 0L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.SINGLE_CTA = 0
-   * }
-   */
-  public static int SINGLE_CTA() {
-    return SINGLE_CTA;
-  }
-
-  private static final int MULTI_CTA = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.MULTI_CTA = 1
-   * }
-   */
-  public static int MULTI_CTA() {
-    return MULTI_CTA;
-  }
-
-  private static final int MULTI_KERNEL = (int) 2L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.MULTI_KERNEL = 2
-   * }
-   */
-  public static int MULTI_KERNEL() {
-    return MULTI_KERNEL;
-  }
-
-  private static final int AUTO = (int) 3L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.AUTO = 3
-   * }
-   */
-  public static int AUTO() {
-    return AUTO;
-  }
-
-  private static final int HASH = (int) 0L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraHashMode.HASH = 0
-   * }
-   */
-  public static int HASH() {
-    return HASH;
-  }
-
-  private static final int SMALL = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraHashMode.SMALL = 1
-   * }
-   */
-  public static int SMALL() {
-    return SMALL;
-  }
-
-  private static final int AUTO_HASH = (int) 2L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsCagraHashMode.AUTO_HASH = 2
-   * }
-   */
-  public static int AUTO_HASH() {
-    return AUTO_HASH;
-  }
-
-  /**
-   * {@snippet lang = c :
-   * typedef struct cuvsCagraSearchParams {
-   *     long max_queries;
-   *     long itopk_size;
-   *     long max_iterations;
-   *     enum cuvsCagraSearchAlgo algo;
-   *     long team_size;
-   *     long search_width;
-   *     long min_iterations;
-   *     long thread_block_size;
-   *     enum cuvsCagraHashMode hashmap_mode;
-   *     long hashmap_min_bitlen;
-   *     float hashmap_max_fill_rate;
-   *     uint32_t num_random_samplings;
-   *     uint64_t rand_xor_mask;
-   * } *cuvsCagraSearchParams_t
-   * }
-   */
-  public static final AddressLayout cuvsCagraSearchParams_t = hnsw_h.C_POINTER;
-  /**
-   * {@snippet lang = c : * typedef cuvsCagraIndex *cuvsCagraIndex_t
-   * }
-   */
-  public static final AddressLayout cuvsCagraIndex_t = hnsw_h.C_POINTER;
-  private static final int NONE = (int) 0L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsHnswHierarchy.NONE = 0
-   * }
-   */
-  public static int NONE() {
-    return NONE;
-  }
-
-  private static final int CPU = (int) 1L;
-
-  /**
-   * {@snippet lang = c : * enum cuvsHnswHierarchy.CPU = 1
-   * }
-   */
-  public static int CPU() {
-    return CPU;
-  }
-
-  /**
-   * {@snippet lang = c :
-   * typedef struct cuvsHnswIndexParams {
-   *     cuvsHnswHierarchy hierarchy;
-   *     int ef_construction;
-   *     int num_threads;
-   * } *cuvsHnswIndexParams_t
-   * }
-   */
-  public static final AddressLayout cuvsHnswIndexParams_t = hnsw_h.C_POINTER;
-  /**
-   * {@snippet lang = c : * typedef cuvsHnswIndex *cuvsHnswIndex_t
-   * }
-   */
-  public static final AddressLayout cuvsHnswIndex_t = hnsw_h.C_POINTER;
-  /**
-   * {@snippet lang = c :
-   * typedef struct cuvsHnswExtendParams {
-   *     int num_threads;
-   * } *cuvsHnswExtendParams_t
-   * }
-   */
-  public static final AddressLayout cuvsHnswExtendParams_t = hnsw_h.C_POINTER;
-  /**
-   * {@snippet lang = c :
-   * typedef struct cuvsHnswSearchParams {
-   *     int32_t ef;
-   *     int32_t num_threads;
-   * } *cuvsHnswSearchParams_t
-   * }
-   */
-  public static final AddressLayout cuvsHnswSearchParams_t = hnsw_h.C_POINTER;
+  public static final AddressLayout cuvsBruteForceIndex_t = BruteForceH.C_POINTER;
   private static final long _POSIX_C_SOURCE = 200809L;
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CagraH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CagraH.java
@@ -39,9 +39,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class brute_force_h {
+public class CagraH {
 
-  brute_force_h() {
+  CagraH() {
     // Should not be called directly
   }
 
@@ -640,471 +640,711 @@ public class brute_force_h {
     return _BITS_STDINT_UINTN_H;
   }
 
+  private static final int true_ = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * #define true 1
+   * }
+   */
+  public static int true_() {
+    return true_;
+  }
+
+  private static final int false_ = (int) 0L;
+
+  /**
+   * {@snippet lang = c : * #define false 0
+   * }
+   */
+  public static int false_() {
+    return false_;
+  }
+
+  private static final int __bool_true_false_are_defined = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * #define __bool_true_false_are_defined 1
+   * }
+   */
+  public static int __bool_true_false_are_defined() {
+    return __bool_true_false_are_defined;
+  }
+
+  private static final int L2Expanded = (int) 0L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.L2Expanded = 0
+   * }
+   */
+  public static int L2Expanded() {
+    return L2Expanded;
+  }
+
+  private static final int L2SqrtExpanded = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.L2SqrtExpanded = 1
+   * }
+   */
+  public static int L2SqrtExpanded() {
+    return L2SqrtExpanded;
+  }
+
+  private static final int CosineExpanded = (int) 2L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.CosineExpanded = 2
+   * }
+   */
+  public static int CosineExpanded() {
+    return CosineExpanded;
+  }
+
+  private static final int L1 = (int) 3L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.L1 = 3
+   * }
+   */
+  public static int L1() {
+    return L1;
+  }
+
+  private static final int L2Unexpanded = (int) 4L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.L2Unexpanded = 4
+   * }
+   */
+  public static int L2Unexpanded() {
+    return L2Unexpanded;
+  }
+
+  private static final int L2SqrtUnexpanded = (int) 5L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.L2SqrtUnexpanded = 5
+   * }
+   */
+  public static int L2SqrtUnexpanded() {
+    return L2SqrtUnexpanded;
+  }
+
+  private static final int InnerProduct = (int) 6L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.InnerProduct = 6
+   * }
+   */
+  public static int InnerProduct() {
+    return InnerProduct;
+  }
+
+  private static final int Linf = (int) 7L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.Linf = 7
+   * }
+   */
+  public static int Linf() {
+    return Linf;
+  }
+
+  private static final int Canberra = (int) 8L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.Canberra = 8
+   * }
+   */
+  public static int Canberra() {
+    return Canberra;
+  }
+
+  private static final int LpUnexpanded = (int) 9L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.LpUnexpanded = 9
+   * }
+   */
+  public static int LpUnexpanded() {
+    return LpUnexpanded;
+  }
+
+  private static final int CorrelationExpanded = (int) 10L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.CorrelationExpanded = 10
+   * }
+   */
+  public static int CorrelationExpanded() {
+    return CorrelationExpanded;
+  }
+
+  private static final int JaccardExpanded = (int) 11L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.JaccardExpanded = 11
+   * }
+   */
+  public static int JaccardExpanded() {
+    return JaccardExpanded;
+  }
+
+  private static final int HellingerExpanded = (int) 12L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.HellingerExpanded = 12
+   * }
+   */
+  public static int HellingerExpanded() {
+    return HellingerExpanded;
+  }
+
+  private static final int Haversine = (int) 13L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.Haversine = 13
+   * }
+   */
+  public static int Haversine() {
+    return Haversine;
+  }
+
+  private static final int BrayCurtis = (int) 14L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.BrayCurtis = 14
+   * }
+   */
+  public static int BrayCurtis() {
+    return BrayCurtis;
+  }
+
+  private static final int JensenShannon = (int) 15L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.JensenShannon = 15
+   * }
+   */
+  public static int JensenShannon() {
+    return JensenShannon;
+  }
+
+  private static final int HammingUnexpanded = (int) 16L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.HammingUnexpanded = 16
+   * }
+   */
+  public static int HammingUnexpanded() {
+    return HammingUnexpanded;
+  }
+
+  private static final int KLDivergence = (int) 17L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.KLDivergence = 17
+   * }
+   */
+  public static int KLDivergence() {
+    return KLDivergence;
+  }
+
+  private static final int RusselRaoExpanded = (int) 18L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.RusselRaoExpanded = 18
+   * }
+   */
+  public static int RusselRaoExpanded() {
+    return RusselRaoExpanded;
+  }
+
+  private static final int DiceExpanded = (int) 19L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.DiceExpanded = 19
+   * }
+   */
+  public static int DiceExpanded() {
+    return DiceExpanded;
+  }
+
+  private static final int Precomputed = (int) 100L;
+
+  /**
+   * {@snippet lang = c : * enum <anonymous>.Precomputed = 100
+   * }
+   */
+  public static int Precomputed() {
+    return Precomputed;
+  }
+
   /**
    * {@snippet lang = c : * typedef unsigned char __u_char
    * }
    */
-  public static final OfByte __u_char = brute_force_h.C_CHAR;
+  public static final OfByte __u_char = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned short __u_short
    * }
    */
-  public static final OfShort __u_short = brute_force_h.C_SHORT;
+  public static final OfShort __u_short = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned int __u_int
    * }
    */
-  public static final OfInt __u_int = brute_force_h.C_INT;
+  public static final OfInt __u_int = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_long
    * }
    */
-  public static final OfLong __u_long = brute_force_h.C_LONG;
+  public static final OfLong __u_long = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char __int8_t
    * }
    */
-  public static final OfByte __int8_t = brute_force_h.C_CHAR;
+  public static final OfByte __int8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned char __uint8_t
    * }
    */
-  public static final OfByte __uint8_t = brute_force_h.C_CHAR;
+  public static final OfByte __uint8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef short __int16_t
    * }
    */
-  public static final OfShort __int16_t = brute_force_h.C_SHORT;
+  public static final OfShort __int16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned short __uint16_t
    * }
    */
-  public static final OfShort __uint16_t = brute_force_h.C_SHORT;
+  public static final OfShort __uint16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef int __int32_t
    * }
    */
-  public static final OfInt __int32_t = brute_force_h.C_INT;
+  public static final OfInt __int32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __uint32_t
    * }
    */
-  public static final OfInt __uint32_t = brute_force_h.C_INT;
+  public static final OfInt __uint32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __int64_t
    * }
    */
-  public static final OfLong __int64_t = brute_force_h.C_LONG;
+  public static final OfLong __int64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uint64_t
    * }
    */
-  public static final OfLong __uint64_t = brute_force_h.C_LONG;
+  public static final OfLong __uint64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int8_t __int_least8_t
    * }
    */
-  public static final OfByte __int_least8_t = brute_force_h.C_CHAR;
+  public static final OfByte __int_least8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint8_t __uint_least8_t
    * }
    */
-  public static final OfByte __uint_least8_t = brute_force_h.C_CHAR;
+  public static final OfByte __uint_least8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t __int_least16_t
    * }
    */
-  public static final OfShort __int_least16_t = brute_force_h.C_SHORT;
+  public static final OfShort __int_least16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint16_t __uint_least16_t
    * }
    */
-  public static final OfShort __uint_least16_t = brute_force_h.C_SHORT;
+  public static final OfShort __uint_least16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t __int_least32_t
    * }
    */
-  public static final OfInt __int_least32_t = brute_force_h.C_INT;
+  public static final OfInt __int_least32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint32_t __uint_least32_t
    * }
    */
-  public static final OfInt __uint_least32_t = brute_force_h.C_INT;
+  public static final OfInt __uint_least32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t __int_least64_t
    * }
    */
-  public static final OfLong __int_least64_t = brute_force_h.C_LONG;
+  public static final OfLong __int_least64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint64_t __uint_least64_t
    * }
    */
-  public static final OfLong __uint_least64_t = brute_force_h.C_LONG;
+  public static final OfLong __uint_least64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __quad_t
    * }
    */
-  public static final OfLong __quad_t = brute_force_h.C_LONG;
+  public static final OfLong __quad_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_quad_t
    * }
    */
-  public static final OfLong __u_quad_t = brute_force_h.C_LONG;
+  public static final OfLong __u_quad_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __intmax_t
    * }
    */
-  public static final OfLong __intmax_t = brute_force_h.C_LONG;
+  public static final OfLong __intmax_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uintmax_t
    * }
    */
-  public static final OfLong __uintmax_t = brute_force_h.C_LONG;
+  public static final OfLong __uintmax_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __dev_t
    * }
    */
-  public static final OfLong __dev_t = brute_force_h.C_LONG;
+  public static final OfLong __dev_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __uid_t
    * }
    */
-  public static final OfInt __uid_t = brute_force_h.C_INT;
+  public static final OfInt __uid_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __gid_t
    * }
    */
-  public static final OfInt __gid_t = brute_force_h.C_INT;
+  public static final OfInt __gid_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino_t
    * }
    */
-  public static final OfLong __ino_t = brute_force_h.C_LONG;
+  public static final OfLong __ino_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino64_t
    * }
    */
-  public static final OfLong __ino64_t = brute_force_h.C_LONG;
+  public static final OfLong __ino64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __mode_t
    * }
    */
-  public static final OfInt __mode_t = brute_force_h.C_INT;
+  public static final OfInt __mode_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __nlink_t
    * }
    */
-  public static final OfLong __nlink_t = brute_force_h.C_LONG;
+  public static final OfLong __nlink_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off_t
    * }
    */
-  public static final OfLong __off_t = brute_force_h.C_LONG;
+  public static final OfLong __off_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off64_t
    * }
    */
-  public static final OfLong __off64_t = brute_force_h.C_LONG;
+  public static final OfLong __off64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __pid_t
    * }
    */
-  public static final OfInt __pid_t = brute_force_h.C_INT;
+  public static final OfInt __pid_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __clock_t
    * }
    */
-  public static final OfLong __clock_t = brute_force_h.C_LONG;
+  public static final OfLong __clock_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim_t
    * }
    */
-  public static final OfLong __rlim_t = brute_force_h.C_LONG;
+  public static final OfLong __rlim_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim64_t
    * }
    */
-  public static final OfLong __rlim64_t = brute_force_h.C_LONG;
+  public static final OfLong __rlim64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __id_t
    * }
    */
-  public static final OfInt __id_t = brute_force_h.C_INT;
+  public static final OfInt __id_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __time_t
    * }
    */
-  public static final OfLong __time_t = brute_force_h.C_LONG;
+  public static final OfLong __time_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __useconds_t
    * }
    */
-  public static final OfInt __useconds_t = brute_force_h.C_INT;
+  public static final OfInt __useconds_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __suseconds_t
    * }
    */
-  public static final OfLong __suseconds_t = brute_force_h.C_LONG;
+  public static final OfLong __suseconds_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __suseconds64_t
    * }
    */
-  public static final OfLong __suseconds64_t = brute_force_h.C_LONG;
+  public static final OfLong __suseconds64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __daddr_t
    * }
    */
-  public static final OfInt __daddr_t = brute_force_h.C_INT;
+  public static final OfInt __daddr_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __key_t
    * }
    */
-  public static final OfInt __key_t = brute_force_h.C_INT;
+  public static final OfInt __key_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __clockid_t
    * }
    */
-  public static final OfInt __clockid_t = brute_force_h.C_INT;
+  public static final OfInt __clockid_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef void *__timer_t
    * }
    */
-  public static final AddressLayout __timer_t = brute_force_h.C_POINTER;
+  public static final AddressLayout __timer_t = CagraH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __blksize_t
    * }
    */
-  public static final OfLong __blksize_t = brute_force_h.C_LONG;
+  public static final OfLong __blksize_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt_t
    * }
    */
-  public static final OfLong __blkcnt_t = brute_force_h.C_LONG;
+  public static final OfLong __blkcnt_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt64_t
    * }
    */
-  public static final OfLong __blkcnt64_t = brute_force_h.C_LONG;
+  public static final OfLong __blkcnt64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt_t
    * }
    */
-  public static final OfLong __fsblkcnt_t = brute_force_h.C_LONG;
+  public static final OfLong __fsblkcnt_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt64_t
    * }
    */
-  public static final OfLong __fsblkcnt64_t = brute_force_h.C_LONG;
+  public static final OfLong __fsblkcnt64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt_t
    * }
    */
-  public static final OfLong __fsfilcnt_t = brute_force_h.C_LONG;
+  public static final OfLong __fsfilcnt_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt64_t
    * }
    */
-  public static final OfLong __fsfilcnt64_t = brute_force_h.C_LONG;
+  public static final OfLong __fsfilcnt64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __fsword_t
    * }
    */
-  public static final OfLong __fsword_t = brute_force_h.C_LONG;
+  public static final OfLong __fsword_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __ssize_t
    * }
    */
-  public static final OfLong __ssize_t = brute_force_h.C_LONG;
+  public static final OfLong __ssize_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __syscall_slong_t
    * }
    */
-  public static final OfLong __syscall_slong_t = brute_force_h.C_LONG;
+  public static final OfLong __syscall_slong_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __syscall_ulong_t
    * }
    */
-  public static final OfLong __syscall_ulong_t = brute_force_h.C_LONG;
+  public static final OfLong __syscall_ulong_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __off64_t __loff_t
    * }
    */
-  public static final OfLong __loff_t = brute_force_h.C_LONG;
+  public static final OfLong __loff_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef char *__caddr_t
    * }
    */
-  public static final AddressLayout __caddr_t = brute_force_h.C_POINTER;
+  public static final AddressLayout __caddr_t = CagraH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __intptr_t
    * }
    */
-  public static final OfLong __intptr_t = brute_force_h.C_LONG;
+  public static final OfLong __intptr_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __socklen_t
    * }
    */
-  public static final OfInt __socklen_t = brute_force_h.C_INT;
+  public static final OfInt __socklen_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __sig_atomic_t
    * }
    */
-  public static final OfInt __sig_atomic_t = brute_force_h.C_INT;
+  public static final OfInt __sig_atomic_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int8_t int8_t
    * }
    */
-  public static final OfByte int8_t = brute_force_h.C_CHAR;
+  public static final OfByte int8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t int16_t
    * }
    */
-  public static final OfShort int16_t = brute_force_h.C_SHORT;
+  public static final OfShort int16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t int32_t
    * }
    */
-  public static final OfInt int32_t = brute_force_h.C_INT;
+  public static final OfInt int32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t int64_t
    * }
    */
-  public static final OfLong int64_t = brute_force_h.C_LONG;
+  public static final OfLong int64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint8_t uint8_t
    * }
    */
-  public static final OfByte uint8_t = brute_force_h.C_CHAR;
+  public static final OfByte uint8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint16_t uint16_t
    * }
    */
-  public static final OfShort uint16_t = brute_force_h.C_SHORT;
+  public static final OfShort uint16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint32_t uint32_t
    * }
    */
-  public static final OfInt uint32_t = brute_force_h.C_INT;
+  public static final OfInt uint32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint64_t uint64_t
    * }
    */
-  public static final OfLong uint64_t = brute_force_h.C_LONG;
+  public static final OfLong uint64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int_least8_t int_least8_t
    * }
    */
-  public static final OfByte int_least8_t = brute_force_h.C_CHAR;
+  public static final OfByte int_least8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int_least16_t int_least16_t
    * }
    */
-  public static final OfShort int_least16_t = brute_force_h.C_SHORT;
+  public static final OfShort int_least16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int_least32_t int_least32_t
    * }
    */
-  public static final OfInt int_least32_t = brute_force_h.C_INT;
+  public static final OfInt int_least32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int_least64_t int_least64_t
    * }
    */
-  public static final OfLong int_least64_t = brute_force_h.C_LONG;
+  public static final OfLong int_least64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint_least8_t uint_least8_t
    * }
    */
-  public static final OfByte uint_least8_t = brute_force_h.C_CHAR;
+  public static final OfByte uint_least8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint_least16_t uint_least16_t
    * }
    */
-  public static final OfShort uint_least16_t = brute_force_h.C_SHORT;
+  public static final OfShort uint_least16_t = CagraH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint_least32_t uint_least32_t
    * }
    */
-  public static final OfInt uint_least32_t = brute_force_h.C_INT;
+  public static final OfInt uint_least32_t = CagraH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint_least64_t uint_least64_t
    * }
    */
-  public static final OfLong uint_least64_t = brute_force_h.C_LONG;
+  public static final OfLong uint_least64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char int_fast8_t
    * }
    */
-  public static final OfByte int_fast8_t = brute_force_h.C_CHAR;
+  public static final OfByte int_fast8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef long int_fast16_t
    * }
    */
-  public static final OfLong int_fast16_t = brute_force_h.C_LONG;
+  public static final OfLong int_fast16_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast32_t
    * }
    */
-  public static final OfLong int_fast32_t = brute_force_h.C_LONG;
+  public static final OfLong int_fast32_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast64_t
    * }
    */
-  public static final OfLong int_fast64_t = brute_force_h.C_LONG;
+  public static final OfLong int_fast64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned char uint_fast8_t
    * }
    */
-  public static final OfByte uint_fast8_t = brute_force_h.C_CHAR;
+  public static final OfByte uint_fast8_t = CagraH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast16_t
    * }
    */
-  public static final OfLong uint_fast16_t = brute_force_h.C_LONG;
+  public static final OfLong uint_fast16_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast32_t
    * }
    */
-  public static final OfLong uint_fast32_t = brute_force_h.C_LONG;
+  public static final OfLong uint_fast32_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast64_t
    * }
    */
-  public static final OfLong uint_fast64_t = brute_force_h.C_LONG;
+  public static final OfLong uint_fast64_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long intptr_t
    * }
    */
-  public static final OfLong intptr_t = brute_force_h.C_LONG;
+  public static final OfLong intptr_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uintptr_t
    * }
    */
-  public static final OfLong uintptr_t = brute_force_h.C_LONG;
+  public static final OfLong uintptr_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __intmax_t intmax_t
    * }
    */
-  public static final OfLong intmax_t = brute_force_h.C_LONG;
+  public static final OfLong intmax_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uintmax_t uintmax_t
    * }
    */
-  public static final OfLong uintmax_t = brute_force_h.C_LONG;
+  public static final OfLong uintmax_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long ptrdiff_t
    * }
    */
-  public static final OfLong ptrdiff_t = brute_force_h.C_LONG;
+  public static final OfLong ptrdiff_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long size_t
    * }
    */
-  public static final OfLong size_t = brute_force_h.C_LONG;
+  public static final OfLong size_t = CagraH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int wchar_t
    * }
    */
-  public static final OfInt wchar_t = brute_force_h.C_INT;
+  public static final OfInt wchar_t = CagraH.C_INT;
   private static final int kDLCPU = (int) 1L;
 
   /**
@@ -1315,11 +1555,157 @@ public class brute_force_h {
     return kDLBool;
   }
 
+  private static final int AUTO_SELECT = (int) 0L;
+
   /**
-   * {@snippet lang = c : * typedef cuvsBruteForceIndex *cuvsBruteForceIndex_t
+   * {@snippet lang = c : * enum cuvsCagraGraphBuildAlgo.AUTO_SELECT = 0
    * }
    */
-  public static final AddressLayout cuvsBruteForceIndex_t = brute_force_h.C_POINTER;
+  public static int AUTO_SELECT() {
+    return AUTO_SELECT;
+  }
+
+  private static final int IVF_PQ = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraGraphBuildAlgo.IVF_PQ = 1
+   * }
+   */
+  public static int IVF_PQ() {
+    return IVF_PQ;
+  }
+
+  private static final int NN_DESCENT = (int) 2L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraGraphBuildAlgo.NN_DESCENT = 2
+   * }
+   */
+  public static int NN_DESCENT() {
+    return NN_DESCENT;
+  }
+
+  /**
+   * {@snippet lang = c :
+   * typedef struct cuvsCagraCompressionParams {
+   *     uint32_t pq_bits;
+   *     uint32_t pq_dim;
+   *     uint32_t vq_n_centers;
+   *     uint32_t kmeans_n_iters;
+   *     double vq_kmeans_trainset_fraction;
+   *     double pq_kmeans_trainset_fraction;
+   * } *cuvsCagraCompressionParams_t
+   * }
+   */
+  public static final AddressLayout cuvsCagraCompressionParams_t = CagraH.C_POINTER;
+  /**
+   * {@snippet lang = c :
+   * typedef struct cuvsCagraIndexParams {
+   *     cuvsDistanceType metric;
+   *     long intermediate_graph_degree;
+   *     long graph_degree;
+   *     enum cuvsCagraGraphBuildAlgo build_algo;
+   *     long nn_descent_niter;
+   *     cuvsCagraCompressionParams_t compression;
+   * } *cuvsCagraIndexParams_t
+   * }
+   */
+  public static final AddressLayout cuvsCagraIndexParams_t = CagraH.C_POINTER;
+  private static final int SINGLE_CTA = (int) 0L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.SINGLE_CTA = 0
+   * }
+   */
+  public static int SINGLE_CTA() {
+    return SINGLE_CTA;
+  }
+
+  private static final int MULTI_CTA = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.MULTI_CTA = 1
+   * }
+   */
+  public static int MULTI_CTA() {
+    return MULTI_CTA;
+  }
+
+  private static final int MULTI_KERNEL = (int) 2L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.MULTI_KERNEL = 2
+   * }
+   */
+  public static int MULTI_KERNEL() {
+    return MULTI_KERNEL;
+  }
+
+  private static final int AUTO = (int) 3L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraSearchAlgo.AUTO = 3
+   * }
+   */
+  public static int AUTO() {
+    return AUTO;
+  }
+
+  private static final int HASH = (int) 0L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraHashMode.HASH = 0
+   * }
+   */
+  public static int HASH() {
+    return HASH;
+  }
+
+  private static final int SMALL = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraHashMode.SMALL = 1
+   * }
+   */
+  public static int SMALL() {
+    return SMALL;
+  }
+
+  private static final int AUTO_HASH = (int) 2L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsCagraHashMode.AUTO_HASH = 2
+   * }
+   */
+  public static int AUTO_HASH() {
+    return AUTO_HASH;
+  }
+
+  /**
+   * {@snippet lang = c :
+   * typedef struct cuvsCagraSearchParams {
+   *     long max_queries;
+   *     long itopk_size;
+   *     long max_iterations;
+   *     enum cuvsCagraSearchAlgo algo;
+   *     long team_size;
+   *     long search_width;
+   *     long min_iterations;
+   *     long thread_block_size;
+   *     enum cuvsCagraHashMode hashmap_mode;
+   *     long hashmap_min_bitlen;
+   *     float hashmap_max_fill_rate;
+   *     uint32_t num_random_samplings;
+   *     uint64_t rand_xor_mask;
+   * } *cuvsCagraSearchParams_t
+   * }
+   */
+  public static final AddressLayout cuvsCagraSearchParams_t = CagraH.C_POINTER;
+  /**
+   * {@snippet lang = c : * typedef cuvsCagraIndex *cuvsCagraIndex_t
+   * }
+   */
+  public static final AddressLayout cuvsCagraIndex_t = CagraH.C_POINTER;
   private static final long _POSIX_C_SOURCE = 200809L;
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSBruteForceIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSBruteForceIndex.java
@@ -34,14 +34,14 @@ import java.util.function.Consumer;
  * }
  * }
  */
-public class cuvsCagraIndex {
+public class CuVSBruteForceIndex {
 
-  cuvsCagraIndex() {
+  CuVSBruteForceIndex() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(cagra_h.C_LONG.withName("addr"),
-      DLDataType.layout().withName("dtype"), MemoryLayout.paddingLayout(4)).withName("$anon$175:9");
+  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(BruteForceH.C_LONG.withName("addr"),
+      DLDataType.layout().withName("dtype"), MemoryLayout.paddingLayout(4)).withName("$anon$22:9");
 
   /**
    * The layout of this struct

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraCompressionParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraCompressionParams.java
@@ -39,16 +39,16 @@ import java.util.function.Consumer;
  * }
  * }
  */
-public class CuvsCagraCompressionParams {
+public class CuVSCagraCompressionParams {
 
-  CuvsCagraCompressionParams() {
+  CuVSCagraCompressionParams() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(cagra_h.C_INT.withName("pq_bits"),
-      cagra_h.C_INT.withName("pq_dim"), cagra_h.C_INT.withName("vq_n_centers"),
-      cagra_h.C_INT.withName("kmeans_n_iters"), cagra_h.C_DOUBLE.withName("vq_kmeans_trainset_fraction"),
-      cagra_h.C_DOUBLE.withName("pq_kmeans_trainset_fraction")).withName("cuvsCagraCompressionParams");
+  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(CagraH.C_INT.withName("pq_bits"),
+      CagraH.C_INT.withName("pq_dim"), CagraH.C_INT.withName("vq_n_centers"),
+      CagraH.C_INT.withName("kmeans_n_iters"), CagraH.C_DOUBLE.withName("vq_kmeans_trainset_fraction"),
+      CagraH.C_DOUBLE.withName("pq_kmeans_trainset_fraction")).withName("cuvsCagraCompressionParams");
 
   /**
    * The layout of this struct

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraIndex.java
@@ -34,14 +34,14 @@ import java.util.function.Consumer;
  * }
  * }
  */
-public class cuvsBruteForceIndex {
+public class CuVSCagraIndex {
 
-  cuvsBruteForceIndex() {
+  CuVSCagraIndex() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(brute_force_h.C_LONG.withName("addr"),
-      DLDataType.layout().withName("dtype"), MemoryLayout.paddingLayout(4)).withName("$anon$22:9");
+  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(CagraH.C_LONG.withName("addr"),
+      DLDataType.layout().withName("dtype"), MemoryLayout.paddingLayout(4)).withName("$anon$175:9");
 
   /**
    * The layout of this struct

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraIndexParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraIndexParams.java
@@ -47,10 +47,10 @@ public class CuVSCagraIndexParams {
   }
 
   private static final GroupLayout $LAYOUT = MemoryLayout
-      .structLayout(cagra_h.C_INT.withName("metric"), MemoryLayout.paddingLayout(4),
-          cagra_h.C_LONG.withName("intermediate_graph_degree"), cagra_h.C_LONG.withName("graph_degree"),
-          cagra_h.C_INT.withName("build_algo"), MemoryLayout.paddingLayout(4),
-          cagra_h.C_LONG.withName("nn_descent_niter"), cagra_h.C_POINTER.withName("compression"))
+      .structLayout(CagraH.C_INT.withName("metric"), MemoryLayout.paddingLayout(4),
+          CagraH.C_LONG.withName("intermediate_graph_degree"), CagraH.C_LONG.withName("graph_degree"),
+          CagraH.C_INT.withName("build_algo"), MemoryLayout.paddingLayout(4),
+          CagraH.C_LONG.withName("nn_descent_niter"), CagraH.C_POINTER.withName("compression"))
       .withName("cuvsCagraIndexParams");
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraSearchParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSCagraSearchParams.java
@@ -47,20 +47,20 @@ import java.util.function.Consumer;
  * }
  * }
  */
-public class CuvsCagraSearchParams {
+public class CuVSCagraSearchParams {
 
-  CuvsCagraSearchParams() {
+  CuVSCagraSearchParams() {
     // Should not be called directly
   }
 
   private static final GroupLayout $LAYOUT = MemoryLayout
-      .structLayout(cagra_h.C_LONG.withName("max_queries"), cagra_h.C_LONG.withName("itopk_size"),
-          cagra_h.C_LONG.withName("max_iterations"), cagra_h.C_INT.withName("algo"), MemoryLayout.paddingLayout(4),
-          cagra_h.C_LONG.withName("team_size"), cagra_h.C_LONG.withName("search_width"),
-          cagra_h.C_LONG.withName("min_iterations"), cagra_h.C_LONG.withName("thread_block_size"),
-          cagra_h.C_INT.withName("hashmap_mode"), MemoryLayout.paddingLayout(4),
-          cagra_h.C_LONG.withName("hashmap_min_bitlen"), cagra_h.C_FLOAT.withName("hashmap_max_fill_rate"),
-          cagra_h.C_INT.withName("num_random_samplings"), cagra_h.C_LONG.withName("rand_xor_mask"))
+      .structLayout(CagraH.C_LONG.withName("max_queries"), CagraH.C_LONG.withName("itopk_size"),
+          CagraH.C_LONG.withName("max_iterations"), CagraH.C_INT.withName("algo"), MemoryLayout.paddingLayout(4),
+          CagraH.C_LONG.withName("team_size"), CagraH.C_LONG.withName("search_width"),
+          CagraH.C_LONG.withName("min_iterations"), CagraH.C_LONG.withName("thread_block_size"),
+          CagraH.C_INT.withName("hashmap_mode"), MemoryLayout.paddingLayout(4),
+          CagraH.C_LONG.withName("hashmap_min_bitlen"), CagraH.C_FLOAT.withName("hashmap_max_fill_rate"),
+          CagraH.C_INT.withName("num_random_samplings"), CagraH.C_LONG.withName("rand_xor_mask"))
       .withName("cuvsCagraSearchParams");
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSFilter.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSFilter.java
@@ -23,27 +23,29 @@ import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.ValueLayout.OfInt;
 import java.lang.foreign.ValueLayout.OfLong;
 import java.util.function.Consumer;
 
 /**
  * {@snippet lang=c :
  * struct {
- *     long long __clang_max_align_nonce1;
- *     long double __clang_max_align_nonce2;
+ *     uintptr_t addr;
+ *     enum cuvsFilterType type;
  * }
  * }
  */
-public class max_align_t {
+public class CuVSFilter {
 
-    max_align_t() {
+    CuVSFilter() {
         // Should not be called directly
     }
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        dlpack_h.C_LONG_LONG.withName("__clang_max_align_nonce1"),
-        MemoryLayout.paddingLayout(24)
-    ).withName("$anon$19:9");
+        BruteForceH.C_LONG.withName("addr"),
+        BruteForceH.C_INT.withName("type"),
+        MemoryLayout.paddingLayout(4)
+    ).withName("$anon$50:9");
 
     /**
      * The layout of this struct
@@ -52,48 +54,92 @@ public class max_align_t {
         return $LAYOUT;
     }
 
-    private static final OfLong __clang_max_align_nonce1$LAYOUT = (OfLong)$LAYOUT.select(groupElement("__clang_max_align_nonce1"));
+    private static final OfLong addr$LAYOUT = (OfLong)$LAYOUT.select(groupElement("addr"));
 
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * long long __clang_max_align_nonce1
+     * uintptr_t addr
      * }
      */
-    public static final OfLong __clang_max_align_nonce1$layout() {
-        return __clang_max_align_nonce1$LAYOUT;
+    public static final OfLong addr$layout() {
+        return addr$LAYOUT;
     }
 
-    private static final long __clang_max_align_nonce1$OFFSET = 0;
+    private static final long addr$OFFSET = 0;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * long long __clang_max_align_nonce1
+     * uintptr_t addr
      * }
      */
-    public static final long __clang_max_align_nonce1$offset() {
-        return __clang_max_align_nonce1$OFFSET;
+    public static final long addr$offset() {
+        return addr$OFFSET;
     }
 
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * long long __clang_max_align_nonce1
+     * uintptr_t addr
      * }
      */
-    public static long __clang_max_align_nonce1(MemorySegment struct) {
-        return struct.get(__clang_max_align_nonce1$LAYOUT, __clang_max_align_nonce1$OFFSET);
+    public static long addr(MemorySegment struct) {
+        return struct.get(addr$LAYOUT, addr$OFFSET);
     }
 
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * long long __clang_max_align_nonce1
+     * uintptr_t addr
      * }
      */
-    public static void __clang_max_align_nonce1(MemorySegment struct, long fieldValue) {
-        struct.set(__clang_max_align_nonce1$LAYOUT, __clang_max_align_nonce1$OFFSET, fieldValue);
+    public static void addr(MemorySegment struct, long fieldValue) {
+        struct.set(addr$LAYOUT, addr$OFFSET, fieldValue);
+    }
+
+    private static final OfInt type$LAYOUT = (OfInt)$LAYOUT.select(groupElement("type"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * enum cuvsFilterType type
+     * }
+     */
+    public static final OfInt type$layout() {
+        return type$LAYOUT;
+    }
+
+    private static final long type$OFFSET = 8;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * enum cuvsFilterType type
+     * }
+     */
+    public static final long type$offset() {
+        return type$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * enum cuvsFilterType type
+     * }
+     */
+    public static int type(MemorySegment struct) {
+        return struct.get(type$LAYOUT, type$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * enum cuvsFilterType type
+     * }
+     */
+    public static void type(MemorySegment struct, int fieldValue) {
+        struct.set(type$LAYOUT, type$OFFSET, fieldValue);
     }
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswExtendParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswExtendParams.java
@@ -28,20 +28,19 @@ import java.util.function.Consumer;
 
 /**
  * {@snippet lang = c :
- * struct cuvsHnswSearchParams {
- *     int32_t ef;
- *     int32_t num_threads;
+ * struct cuvsHnswExtendParams {
+ *     int num_threads;
  * }
  * }
  */
-public class CuvsHnswSearchParams {
+public class CuVSHnswExtendParams {
 
-  CuvsHnswSearchParams() {
+  CuVSHnswExtendParams() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout
-      .structLayout(hnsw_h.C_INT.withName("ef"), hnsw_h.C_INT.withName("num_threads")).withName("cuvsHnswSearchParams");
+  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(HnswH.C_INT.withName("num_threads"))
+      .withName("cuvsHnswExtendParams");
 
   /**
    * The layout of this struct
@@ -50,62 +49,22 @@ public class CuvsHnswSearchParams {
     return $LAYOUT;
   }
 
-  private static final OfInt ef$LAYOUT = (OfInt) $LAYOUT.select(groupElement("ef"));
-
-  /**
-   * Layout for field:
-   * {@snippet lang = c : * int32_t ef
-   * }
-   */
-  public static final OfInt ef$layout() {
-    return ef$LAYOUT;
-  }
-
-  private static final long ef$OFFSET = 0;
-
-  /**
-   * Offset for field:
-   * {@snippet lang = c : * int32_t ef
-   * }
-   */
-  public static final long ef$offset() {
-    return ef$OFFSET;
-  }
-
-  /**
-   * Getter for field:
-   * {@snippet lang = c : * int32_t ef
-   * }
-   */
-  public static int ef(MemorySegment struct) {
-    return struct.get(ef$LAYOUT, ef$OFFSET);
-  }
-
-  /**
-   * Setter for field:
-   * {@snippet lang = c : * int32_t ef
-   * }
-   */
-  public static void ef(MemorySegment struct, int fieldValue) {
-    struct.set(ef$LAYOUT, ef$OFFSET, fieldValue);
-  }
-
   private static final OfInt num_threads$LAYOUT = (OfInt) $LAYOUT.select(groupElement("num_threads"));
 
   /**
    * Layout for field:
-   * {@snippet lang = c : * int32_t num_threads
+   * {@snippet lang = c : * int num_threads
    * }
    */
   public static final OfInt num_threads$layout() {
     return num_threads$LAYOUT;
   }
 
-  private static final long num_threads$OFFSET = 4;
+  private static final long num_threads$OFFSET = 0;
 
   /**
    * Offset for field:
-   * {@snippet lang = c : * int32_t num_threads
+   * {@snippet lang = c : * int num_threads
    * }
    */
   public static final long num_threads$offset() {
@@ -114,7 +73,7 @@ public class CuvsHnswSearchParams {
 
   /**
    * Getter for field:
-   * {@snippet lang = c : * int32_t num_threads
+   * {@snippet lang = c : * int num_threads
    * }
    */
   public static int num_threads(MemorySegment struct) {
@@ -123,7 +82,7 @@ public class CuvsHnswSearchParams {
 
   /**
    * Setter for field:
-   * {@snippet lang = c : * int32_t num_threads
+   * {@snippet lang = c : * int num_threads
    * }
    */
   public static void num_threads(MemorySegment struct, int fieldValue) {

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswIndex.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswIndex.java
@@ -23,24 +23,25 @@ import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.ValueLayout.OfInt;
+import java.lang.foreign.ValueLayout.OfLong;
 import java.util.function.Consumer;
 
 /**
  * {@snippet lang = c :
- * struct cuvsHnswExtendParams {
- *     int num_threads;
+ * struct {
+ *     uintptr_t addr;
+ *     DLDataType dtype;
  * }
  * }
  */
-public class CuvsHnswExtendParams {
+public class CuVSHnswIndex {
 
-  CuvsHnswExtendParams() {
+  CuVSHnswIndex() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(hnsw_h.C_INT.withName("num_threads"))
-      .withName("cuvsHnswExtendParams");
+  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(HnswH.C_LONG.withName("addr"),
+      DLDataType.layout().withName("dtype"), MemoryLayout.paddingLayout(4)).withName("$anon$66:9");
 
   /**
    * The layout of this struct
@@ -49,44 +50,84 @@ public class CuvsHnswExtendParams {
     return $LAYOUT;
   }
 
-  private static final OfInt num_threads$LAYOUT = (OfInt) $LAYOUT.select(groupElement("num_threads"));
+  private static final OfLong addr$LAYOUT = (OfLong) $LAYOUT.select(groupElement("addr"));
 
   /**
    * Layout for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * uintptr_t addr
    * }
    */
-  public static final OfInt num_threads$layout() {
-    return num_threads$LAYOUT;
+  public static final OfLong addr$layout() {
+    return addr$LAYOUT;
   }
 
-  private static final long num_threads$OFFSET = 0;
+  private static final long addr$OFFSET = 0;
 
   /**
    * Offset for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * uintptr_t addr
    * }
    */
-  public static final long num_threads$offset() {
-    return num_threads$OFFSET;
+  public static final long addr$offset() {
+    return addr$OFFSET;
   }
 
   /**
    * Getter for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * uintptr_t addr
    * }
    */
-  public static int num_threads(MemorySegment struct) {
-    return struct.get(num_threads$LAYOUT, num_threads$OFFSET);
+  public static long addr(MemorySegment struct) {
+    return struct.get(addr$LAYOUT, addr$OFFSET);
   }
 
   /**
    * Setter for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * uintptr_t addr
    * }
    */
-  public static void num_threads(MemorySegment struct, int fieldValue) {
-    struct.set(num_threads$LAYOUT, num_threads$OFFSET, fieldValue);
+  public static void addr(MemorySegment struct, long fieldValue) {
+    struct.set(addr$LAYOUT, addr$OFFSET, fieldValue);
+  }
+
+  private static final GroupLayout dtype$LAYOUT = (GroupLayout) $LAYOUT.select(groupElement("dtype"));
+
+  /**
+   * Layout for field:
+   * {@snippet lang = c : * DLDataType dtype
+   * }
+   */
+  public static final GroupLayout dtype$layout() {
+    return dtype$LAYOUT;
+  }
+
+  private static final long dtype$OFFSET = 8;
+
+  /**
+   * Offset for field:
+   * {@snippet lang = c : * DLDataType dtype
+   * }
+   */
+  public static final long dtype$offset() {
+    return dtype$OFFSET;
+  }
+
+  /**
+   * Getter for field:
+   * {@snippet lang = c : * DLDataType dtype
+   * }
+   */
+  public static MemorySegment dtype(MemorySegment struct) {
+    return struct.asSlice(dtype$OFFSET, dtype$LAYOUT.byteSize());
+  }
+
+  /**
+   * Setter for field:
+   * {@snippet lang = c : * DLDataType dtype
+   * }
+   */
+  public static void dtype(MemorySegment struct, MemorySegment fieldValue) {
+    MemorySegment.copy(fieldValue, 0L, struct, dtype$OFFSET, dtype$LAYOUT.byteSize());
   }
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswIndexParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswIndexParams.java
@@ -17,32 +17,32 @@
 package com.nvidia.cuvs.panama;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
-import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.SequenceLayout;
-import java.lang.invoke.VarHandle;
+import java.lang.foreign.ValueLayout.OfInt;
 import java.util.function.Consumer;
 
 /**
  * {@snippet lang = c :
- * struct {
- *     int __val[2];
+ * struct cuvsHnswIndexParams {
+ *     cuvsHnswHierarchy hierarchy;
+ *     int ef_construction;
+ *     int num_threads;
  * }
  * }
  */
-public class __fsid_t {
+public class CuVSHnswIndexParams {
 
-  __fsid_t() {
+  CuVSHnswIndexParams() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout
-      .structLayout(MemoryLayout.sequenceLayout(2, cagra_h.C_INT).withName("__val")).withName("$anon$155:12");
+  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(HnswH.C_INT.withName("hierarchy"),
+      HnswH.C_INT.withName("ef_construction"), HnswH.C_INT.withName("num_threads")).withName("cuvsHnswIndexParams");
 
   /**
    * The layout of this struct
@@ -51,75 +51,124 @@ public class __fsid_t {
     return $LAYOUT;
   }
 
-  private static final SequenceLayout __val$LAYOUT = (SequenceLayout) $LAYOUT.select(groupElement("__val"));
+  private static final OfInt hierarchy$LAYOUT = (OfInt) $LAYOUT.select(groupElement("hierarchy"));
 
   /**
    * Layout for field:
-   * {@snippet lang = c : * int __val[2]
+   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
    * }
    */
-  public static final SequenceLayout __val$layout() {
-    return __val$LAYOUT;
+  public static final OfInt hierarchy$layout() {
+    return hierarchy$LAYOUT;
   }
 
-  private static final long __val$OFFSET = 0;
+  private static final long hierarchy$OFFSET = 0;
 
   /**
    * Offset for field:
-   * {@snippet lang = c : * int __val[2]
+   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
    * }
    */
-  public static final long __val$offset() {
-    return __val$OFFSET;
+  public static final long hierarchy$offset() {
+    return hierarchy$OFFSET;
   }
 
   /**
    * Getter for field:
-   * {@snippet lang = c : * int __val[2]
+   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
    * }
    */
-  public static MemorySegment __val(MemorySegment struct) {
-    return struct.asSlice(__val$OFFSET, __val$LAYOUT.byteSize());
+  public static int hierarchy(MemorySegment struct) {
+    return struct.get(hierarchy$LAYOUT, hierarchy$OFFSET);
   }
 
   /**
    * Setter for field:
-   * {@snippet lang = c : * int __val[2]
+   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
    * }
    */
-  public static void __val(MemorySegment struct, MemorySegment fieldValue) {
-    MemorySegment.copy(fieldValue, 0L, struct, __val$OFFSET, __val$LAYOUT.byteSize());
+  public static void hierarchy(MemorySegment struct, int fieldValue) {
+    struct.set(hierarchy$LAYOUT, hierarchy$OFFSET, fieldValue);
   }
 
-  private static long[] __val$DIMS = { 2 };
+  private static final OfInt ef_construction$LAYOUT = (OfInt) $LAYOUT.select(groupElement("ef_construction"));
 
   /**
-   * Dimensions for array field:
-   * {@snippet lang = c : * int __val[2]
+   * Layout for field:
+   * {@snippet lang = c : * int ef_construction
    * }
    */
-  public static long[] __val$dimensions() {
-    return __val$DIMS;
+  public static final OfInt ef_construction$layout() {
+    return ef_construction$LAYOUT;
   }
 
-  private static final VarHandle __val$ELEM_HANDLE = __val$LAYOUT.varHandle(sequenceElement());
+  private static final long ef_construction$OFFSET = 4;
 
   /**
-   * Indexed getter for field:
-   * {@snippet lang = c : * int __val[2]
+   * Offset for field:
+   * {@snippet lang = c : * int ef_construction
    * }
    */
-  public static int __val(MemorySegment struct, long index0) {
-    return (int) __val$ELEM_HANDLE.get(struct, 0L, index0);
+  public static final long ef_construction$offset() {
+    return ef_construction$OFFSET;
   }
 
   /**
-   * Indexed setter for field:
-   * {@snippet lang = c : * int __val[2]
+   * Getter for field:
+   * {@snippet lang = c : * int ef_construction
    * }
    */
-  public static void __val(MemorySegment struct, long index0, int fieldValue) {
-    __val$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+  public static int ef_construction(MemorySegment struct) {
+    return struct.get(ef_construction$LAYOUT, ef_construction$OFFSET);
+  }
+
+  /**
+   * Setter for field:
+   * {@snippet lang = c : * int ef_construction
+   * }
+   */
+  public static void ef_construction(MemorySegment struct, int fieldValue) {
+    struct.set(ef_construction$LAYOUT, ef_construction$OFFSET, fieldValue);
+  }
+
+  private static final OfInt num_threads$LAYOUT = (OfInt) $LAYOUT.select(groupElement("num_threads"));
+
+  /**
+   * Layout for field:
+   * {@snippet lang = c : * int num_threads
+   * }
+   */
+  public static final OfInt num_threads$layout() {
+    return num_threads$LAYOUT;
+  }
+
+  private static final long num_threads$OFFSET = 8;
+
+  /**
+   * Offset for field:
+   * {@snippet lang = c : * int num_threads
+   * }
+   */
+  public static final long num_threads$offset() {
+    return num_threads$OFFSET;
+  }
+
+  /**
+   * Getter for field:
+   * {@snippet lang = c : * int num_threads
+   * }
+   */
+  public static int num_threads(MemorySegment struct) {
+    return struct.get(num_threads$LAYOUT, num_threads$OFFSET);
+  }
+
+  /**
+   * Setter for field:
+   * {@snippet lang = c : * int num_threads
+   * }
+   */
+  public static void num_threads(MemorySegment struct, int fieldValue) {
+    struct.set(num_threads$LAYOUT, num_threads$OFFSET, fieldValue);
   }
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswSearchParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/CuVSHnswSearchParams.java
@@ -28,21 +28,20 @@ import java.util.function.Consumer;
 
 /**
  * {@snippet lang = c :
- * struct cuvsHnswIndexParams {
- *     cuvsHnswHierarchy hierarchy;
- *     int ef_construction;
- *     int num_threads;
+ * struct cuvsHnswSearchParams {
+ *     int32_t ef;
+ *     int32_t num_threads;
  * }
  * }
  */
-public class CuvsHnswIndexParams {
+public class CuVSHnswSearchParams {
 
-  CuvsHnswIndexParams() {
+  CuVSHnswSearchParams() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(hnsw_h.C_INT.withName("hierarchy"),
-      hnsw_h.C_INT.withName("ef_construction"), hnsw_h.C_INT.withName("num_threads")).withName("cuvsHnswIndexParams");
+  private static final GroupLayout $LAYOUT = MemoryLayout
+      .structLayout(HnswH.C_INT.withName("ef"), HnswH.C_INT.withName("num_threads")).withName("cuvsHnswSearchParams");
 
   /**
    * The layout of this struct
@@ -51,102 +50,62 @@ public class CuvsHnswIndexParams {
     return $LAYOUT;
   }
 
-  private static final OfInt hierarchy$LAYOUT = (OfInt) $LAYOUT.select(groupElement("hierarchy"));
+  private static final OfInt ef$LAYOUT = (OfInt) $LAYOUT.select(groupElement("ef"));
 
   /**
    * Layout for field:
-   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
+   * {@snippet lang = c : * int32_t ef
    * }
    */
-  public static final OfInt hierarchy$layout() {
-    return hierarchy$LAYOUT;
+  public static final OfInt ef$layout() {
+    return ef$LAYOUT;
   }
 
-  private static final long hierarchy$OFFSET = 0;
+  private static final long ef$OFFSET = 0;
 
   /**
    * Offset for field:
-   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
+   * {@snippet lang = c : * int32_t ef
    * }
    */
-  public static final long hierarchy$offset() {
-    return hierarchy$OFFSET;
+  public static final long ef$offset() {
+    return ef$OFFSET;
   }
 
   /**
    * Getter for field:
-   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
+   * {@snippet lang = c : * int32_t ef
    * }
    */
-  public static int hierarchy(MemorySegment struct) {
-    return struct.get(hierarchy$LAYOUT, hierarchy$OFFSET);
+  public static int ef(MemorySegment struct) {
+    return struct.get(ef$LAYOUT, ef$OFFSET);
   }
 
   /**
    * Setter for field:
-   * {@snippet lang = c : * cuvsHnswHierarchy hierarchy
+   * {@snippet lang = c : * int32_t ef
    * }
    */
-  public static void hierarchy(MemorySegment struct, int fieldValue) {
-    struct.set(hierarchy$LAYOUT, hierarchy$OFFSET, fieldValue);
-  }
-
-  private static final OfInt ef_construction$LAYOUT = (OfInt) $LAYOUT.select(groupElement("ef_construction"));
-
-  /**
-   * Layout for field:
-   * {@snippet lang = c : * int ef_construction
-   * }
-   */
-  public static final OfInt ef_construction$layout() {
-    return ef_construction$LAYOUT;
-  }
-
-  private static final long ef_construction$OFFSET = 4;
-
-  /**
-   * Offset for field:
-   * {@snippet lang = c : * int ef_construction
-   * }
-   */
-  public static final long ef_construction$offset() {
-    return ef_construction$OFFSET;
-  }
-
-  /**
-   * Getter for field:
-   * {@snippet lang = c : * int ef_construction
-   * }
-   */
-  public static int ef_construction(MemorySegment struct) {
-    return struct.get(ef_construction$LAYOUT, ef_construction$OFFSET);
-  }
-
-  /**
-   * Setter for field:
-   * {@snippet lang = c : * int ef_construction
-   * }
-   */
-  public static void ef_construction(MemorySegment struct, int fieldValue) {
-    struct.set(ef_construction$LAYOUT, ef_construction$OFFSET, fieldValue);
+  public static void ef(MemorySegment struct, int fieldValue) {
+    struct.set(ef$LAYOUT, ef$OFFSET, fieldValue);
   }
 
   private static final OfInt num_threads$LAYOUT = (OfInt) $LAYOUT.select(groupElement("num_threads"));
 
   /**
    * Layout for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * int32_t num_threads
    * }
    */
   public static final OfInt num_threads$layout() {
     return num_threads$LAYOUT;
   }
 
-  private static final long num_threads$OFFSET = 8;
+  private static final long num_threads$OFFSET = 4;
 
   /**
    * Offset for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * int32_t num_threads
    * }
    */
   public static final long num_threads$offset() {
@@ -155,7 +114,7 @@ public class CuvsHnswIndexParams {
 
   /**
    * Getter for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * int32_t num_threads
    * }
    */
   public static int num_threads(MemorySegment struct) {
@@ -164,7 +123,7 @@ public class CuvsHnswIndexParams {
 
   /**
    * Setter for field:
-   * {@snippet lang = c : * int num_threads
+   * {@snippet lang = c : * int32_t num_threads
    * }
    */
   public static void num_threads(MemorySegment struct, int fieldValue) {

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLDataType.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLDataType.java
@@ -43,9 +43,9 @@ public class DLDataType {
     }
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        dlpack_h.C_CHAR.withName("code"),
-        dlpack_h.C_CHAR.withName("bits"),
-        dlpack_h.C_SHORT.withName("lanes")
+        DlpackH.C_CHAR.withName("code"),
+        DlpackH.C_CHAR.withName("bits"),
+        DlpackH.C_SHORT.withName("lanes")
     ).withName("$anon$174:9");
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLDevice.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLDevice.java
@@ -41,8 +41,8 @@ public class DLDevice {
     }
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        dlpack_h.C_INT.withName("device_type"),
-        dlpack_h.C_INT.withName("device_id")
+        DlpackH.C_INT.withName("device_type"),
+        DlpackH.C_INT.withName("device_id")
     ).withName("$anon$126:9");
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLManagedTensor.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLManagedTensor.java
@@ -46,8 +46,8 @@ public class DLManagedTensor {
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
         DLTensor.layout().withName("dl_tensor"),
-        dlpack_h.C_POINTER.withName("manager_ctx"),
-        dlpack_h.C_POINTER.withName("deleter")
+        DlpackH.C_POINTER.withName("manager_ctx"),
+        DlpackH.C_POINTER.withName("deleter")
     ).withName("DLManagedTensor");
 
     /**
@@ -164,7 +164,7 @@ public class DLManagedTensor {
         }
 
         private static final FunctionDescriptor $DESC = FunctionDescriptor.ofVoid(
-            dlpack_h.C_POINTER
+            DlpackH.C_POINTER
         );
 
         /**
@@ -174,7 +174,7 @@ public class DLManagedTensor {
             return $DESC;
         }
 
-        private static final MethodHandle UP$MH = dlpack_h.upcallHandle(deleter.Function.class, "apply", $DESC);
+        private static final MethodHandle UP$MH = DlpackH.upcallHandle(deleter.Function.class, "apply", $DESC);
 
         /**
          * Allocates a new upcall stub, whose implementation is defined by {@code fi}.

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLManagedTensorVersioned.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLManagedTensorVersioned.java
@@ -49,9 +49,9 @@ public class DLManagedTensorVersioned {
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
         DLPackVersion.layout().withName("version"),
-        dlpack_h.C_POINTER.withName("manager_ctx"),
-        dlpack_h.C_POINTER.withName("deleter"),
-        dlpack_h.C_LONG.withName("flags"),
+        DlpackH.C_POINTER.withName("manager_ctx"),
+        DlpackH.C_POINTER.withName("deleter"),
+        DlpackH.C_LONG.withName("flags"),
         DLTensor.layout().withName("dl_tensor")
     ).withName("DLManagedTensorVersioned");
 
@@ -169,7 +169,7 @@ public class DLManagedTensorVersioned {
         }
 
         private static final FunctionDescriptor $DESC = FunctionDescriptor.ofVoid(
-            dlpack_h.C_POINTER
+            DlpackH.C_POINTER
         );
 
         /**
@@ -179,7 +179,7 @@ public class DLManagedTensorVersioned {
             return $DESC;
         }
 
-        private static final MethodHandle UP$MH = dlpack_h.upcallHandle(deleter.Function.class, "apply", $DESC);
+        private static final MethodHandle UP$MH = DlpackH.upcallHandle(deleter.Function.class, "apply", $DESC);
 
         /**
          * Allocates a new upcall stub, whose implementation is defined by {@code fi}.

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLPackVersion.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLPackVersion.java
@@ -41,8 +41,8 @@ public class DLPackVersion {
     }
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        dlpack_h.C_INT.withName("major"),
-        dlpack_h.C_INT.withName("minor")
+        DlpackH.C_INT.withName("major"),
+        DlpackH.C_INT.withName("minor")
     ).withName("$anon$61:9");
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLTensor.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DLTensor.java
@@ -48,13 +48,13 @@ public class DLTensor {
     }
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        dlpack_h.C_POINTER.withName("data"),
+        DlpackH.C_POINTER.withName("data"),
         DLDevice.layout().withName("device"),
-        dlpack_h.C_INT.withName("ndim"),
+        DlpackH.C_INT.withName("ndim"),
         DLDataType.layout().withName("dtype"),
-        dlpack_h.C_POINTER.withName("shape"),
-        dlpack_h.C_POINTER.withName("strides"),
-        dlpack_h.C_LONG.withName("byte_offset")
+        DlpackH.C_POINTER.withName("shape"),
+        DlpackH.C_POINTER.withName("strides"),
+        DlpackH.C_LONG.withName("byte_offset")
     ).withName("$anon$192:9");
 
     /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DistanceH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DistanceH.java
@@ -26,9 +26,9 @@ import java.util.stream.*;
 import static java.lang.foreign.ValueLayout.*;
 import static java.lang.foreign.MemoryLayout.PathElement.*;
 
-public class distance_h {
+public class DistanceH {
 
-    distance_h() {
+    DistanceH() {
         // Should not be called directly
     }
 

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DlpackH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/DlpackH.java
@@ -39,9 +39,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class dlpack_h {
+public class DlpackH {
 
-    dlpack_h() {
+    DlpackH() {
         // Should not be called directly
     }
 
@@ -595,559 +595,559 @@ public class dlpack_h {
      * typedef unsigned char __u_char
      * }
      */
-    public static final OfByte __u_char = dlpack_h.C_CHAR;
+    public static final OfByte __u_char = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef unsigned short __u_short
      * }
      */
-    public static final OfShort __u_short = dlpack_h.C_SHORT;
+    public static final OfShort __u_short = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __u_int
      * }
      */
-    public static final OfInt __u_int = dlpack_h.C_INT;
+    public static final OfInt __u_int = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __u_long
      * }
      */
-    public static final OfLong __u_long = dlpack_h.C_LONG;
+    public static final OfLong __u_long = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef signed char __int8_t
      * }
      */
-    public static final OfByte __int8_t = dlpack_h.C_CHAR;
+    public static final OfByte __int8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef unsigned char __uint8_t
      * }
      */
-    public static final OfByte __uint8_t = dlpack_h.C_CHAR;
+    public static final OfByte __uint8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef short __int16_t
      * }
      */
-    public static final OfShort __int16_t = dlpack_h.C_SHORT;
+    public static final OfShort __int16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef unsigned short __uint16_t
      * }
      */
-    public static final OfShort __uint16_t = dlpack_h.C_SHORT;
+    public static final OfShort __uint16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef int __int32_t
      * }
      */
-    public static final OfInt __int32_t = dlpack_h.C_INT;
+    public static final OfInt __int32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __uint32_t
      * }
      */
-    public static final OfInt __uint32_t = dlpack_h.C_INT;
+    public static final OfInt __uint32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef long __int64_t
      * }
      */
-    public static final OfLong __int64_t = dlpack_h.C_LONG;
+    public static final OfLong __int64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __uint64_t
      * }
      */
-    public static final OfLong __uint64_t = dlpack_h.C_LONG;
+    public static final OfLong __uint64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __int8_t __int_least8_t
      * }
      */
-    public static final OfByte __int_least8_t = dlpack_h.C_CHAR;
+    public static final OfByte __int_least8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef __uint8_t __uint_least8_t
      * }
      */
-    public static final OfByte __uint_least8_t = dlpack_h.C_CHAR;
+    public static final OfByte __uint_least8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef __int16_t __int_least16_t
      * }
      */
-    public static final OfShort __int_least16_t = dlpack_h.C_SHORT;
+    public static final OfShort __int_least16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef __uint16_t __uint_least16_t
      * }
      */
-    public static final OfShort __uint_least16_t = dlpack_h.C_SHORT;
+    public static final OfShort __uint_least16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef __int32_t __int_least32_t
      * }
      */
-    public static final OfInt __int_least32_t = dlpack_h.C_INT;
+    public static final OfInt __int_least32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __uint32_t __uint_least32_t
      * }
      */
-    public static final OfInt __uint_least32_t = dlpack_h.C_INT;
+    public static final OfInt __uint_least32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __int64_t __int_least64_t
      * }
      */
-    public static final OfLong __int_least64_t = dlpack_h.C_LONG;
+    public static final OfLong __int_least64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __uint64_t __uint_least64_t
      * }
      */
-    public static final OfLong __uint_least64_t = dlpack_h.C_LONG;
+    public static final OfLong __uint_least64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __quad_t
      * }
      */
-    public static final OfLong __quad_t = dlpack_h.C_LONG;
+    public static final OfLong __quad_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __u_quad_t
      * }
      */
-    public static final OfLong __u_quad_t = dlpack_h.C_LONG;
+    public static final OfLong __u_quad_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __intmax_t
      * }
      */
-    public static final OfLong __intmax_t = dlpack_h.C_LONG;
+    public static final OfLong __intmax_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __uintmax_t
      * }
      */
-    public static final OfLong __uintmax_t = dlpack_h.C_LONG;
+    public static final OfLong __uintmax_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __dev_t
      * }
      */
-    public static final OfLong __dev_t = dlpack_h.C_LONG;
+    public static final OfLong __dev_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __uid_t
      * }
      */
-    public static final OfInt __uid_t = dlpack_h.C_INT;
+    public static final OfInt __uid_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __gid_t
      * }
      */
-    public static final OfInt __gid_t = dlpack_h.C_INT;
+    public static final OfInt __gid_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __ino_t
      * }
      */
-    public static final OfLong __ino_t = dlpack_h.C_LONG;
+    public static final OfLong __ino_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __ino64_t
      * }
      */
-    public static final OfLong __ino64_t = dlpack_h.C_LONG;
+    public static final OfLong __ino64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __mode_t
      * }
      */
-    public static final OfInt __mode_t = dlpack_h.C_INT;
+    public static final OfInt __mode_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __nlink_t
      * }
      */
-    public static final OfLong __nlink_t = dlpack_h.C_LONG;
+    public static final OfLong __nlink_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __off_t
      * }
      */
-    public static final OfLong __off_t = dlpack_h.C_LONG;
+    public static final OfLong __off_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __off64_t
      * }
      */
-    public static final OfLong __off64_t = dlpack_h.C_LONG;
+    public static final OfLong __off64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef int __pid_t
      * }
      */
-    public static final OfInt __pid_t = dlpack_h.C_INT;
+    public static final OfInt __pid_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef long __clock_t
      * }
      */
-    public static final OfLong __clock_t = dlpack_h.C_LONG;
+    public static final OfLong __clock_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __rlim_t
      * }
      */
-    public static final OfLong __rlim_t = dlpack_h.C_LONG;
+    public static final OfLong __rlim_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __rlim64_t
      * }
      */
-    public static final OfLong __rlim64_t = dlpack_h.C_LONG;
+    public static final OfLong __rlim64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __id_t
      * }
      */
-    public static final OfInt __id_t = dlpack_h.C_INT;
+    public static final OfInt __id_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef long __time_t
      * }
      */
-    public static final OfLong __time_t = dlpack_h.C_LONG;
+    public static final OfLong __time_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __useconds_t
      * }
      */
-    public static final OfInt __useconds_t = dlpack_h.C_INT;
+    public static final OfInt __useconds_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef long __suseconds_t
      * }
      */
-    public static final OfLong __suseconds_t = dlpack_h.C_LONG;
+    public static final OfLong __suseconds_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __suseconds64_t
      * }
      */
-    public static final OfLong __suseconds64_t = dlpack_h.C_LONG;
+    public static final OfLong __suseconds64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef int __daddr_t
      * }
      */
-    public static final OfInt __daddr_t = dlpack_h.C_INT;
+    public static final OfInt __daddr_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef int __key_t
      * }
      */
-    public static final OfInt __key_t = dlpack_h.C_INT;
+    public static final OfInt __key_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef int __clockid_t
      * }
      */
-    public static final OfInt __clockid_t = dlpack_h.C_INT;
+    public static final OfInt __clockid_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef void *__timer_t
      * }
      */
-    public static final AddressLayout __timer_t = dlpack_h.C_POINTER;
+    public static final AddressLayout __timer_t = DlpackH.C_POINTER;
     /**
      * {@snippet lang=c :
      * typedef long __blksize_t
      * }
      */
-    public static final OfLong __blksize_t = dlpack_h.C_LONG;
+    public static final OfLong __blksize_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __blkcnt_t
      * }
      */
-    public static final OfLong __blkcnt_t = dlpack_h.C_LONG;
+    public static final OfLong __blkcnt_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __blkcnt64_t
      * }
      */
-    public static final OfLong __blkcnt64_t = dlpack_h.C_LONG;
+    public static final OfLong __blkcnt64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __fsblkcnt_t
      * }
      */
-    public static final OfLong __fsblkcnt_t = dlpack_h.C_LONG;
+    public static final OfLong __fsblkcnt_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __fsblkcnt64_t
      * }
      */
-    public static final OfLong __fsblkcnt64_t = dlpack_h.C_LONG;
+    public static final OfLong __fsblkcnt64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __fsfilcnt_t
      * }
      */
-    public static final OfLong __fsfilcnt_t = dlpack_h.C_LONG;
+    public static final OfLong __fsfilcnt_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __fsfilcnt64_t
      * }
      */
-    public static final OfLong __fsfilcnt64_t = dlpack_h.C_LONG;
+    public static final OfLong __fsfilcnt64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __fsword_t
      * }
      */
-    public static final OfLong __fsword_t = dlpack_h.C_LONG;
+    public static final OfLong __fsword_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __ssize_t
      * }
      */
-    public static final OfLong __ssize_t = dlpack_h.C_LONG;
+    public static final OfLong __ssize_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long __syscall_slong_t
      * }
      */
-    public static final OfLong __syscall_slong_t = dlpack_h.C_LONG;
+    public static final OfLong __syscall_slong_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long __syscall_ulong_t
      * }
      */
-    public static final OfLong __syscall_ulong_t = dlpack_h.C_LONG;
+    public static final OfLong __syscall_ulong_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __off64_t __loff_t
      * }
      */
-    public static final OfLong __loff_t = dlpack_h.C_LONG;
+    public static final OfLong __loff_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef char *__caddr_t
      * }
      */
-    public static final AddressLayout __caddr_t = dlpack_h.C_POINTER;
+    public static final AddressLayout __caddr_t = DlpackH.C_POINTER;
     /**
      * {@snippet lang=c :
      * typedef long __intptr_t
      * }
      */
-    public static final OfLong __intptr_t = dlpack_h.C_LONG;
+    public static final OfLong __intptr_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned int __socklen_t
      * }
      */
-    public static final OfInt __socklen_t = dlpack_h.C_INT;
+    public static final OfInt __socklen_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef int __sig_atomic_t
      * }
      */
-    public static final OfInt __sig_atomic_t = dlpack_h.C_INT;
+    public static final OfInt __sig_atomic_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __int8_t int8_t
      * }
      */
-    public static final OfByte int8_t = dlpack_h.C_CHAR;
+    public static final OfByte int8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef __int16_t int16_t
      * }
      */
-    public static final OfShort int16_t = dlpack_h.C_SHORT;
+    public static final OfShort int16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef __int32_t int32_t
      * }
      */
-    public static final OfInt int32_t = dlpack_h.C_INT;
+    public static final OfInt int32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __int64_t int64_t
      * }
      */
-    public static final OfLong int64_t = dlpack_h.C_LONG;
+    public static final OfLong int64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __uint8_t uint8_t
      * }
      */
-    public static final OfByte uint8_t = dlpack_h.C_CHAR;
+    public static final OfByte uint8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef __uint16_t uint16_t
      * }
      */
-    public static final OfShort uint16_t = dlpack_h.C_SHORT;
+    public static final OfShort uint16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef __uint32_t uint32_t
      * }
      */
-    public static final OfInt uint32_t = dlpack_h.C_INT;
+    public static final OfInt uint32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __uint64_t uint64_t
      * }
      */
-    public static final OfLong uint64_t = dlpack_h.C_LONG;
+    public static final OfLong uint64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __int_least8_t int_least8_t
      * }
      */
-    public static final OfByte int_least8_t = dlpack_h.C_CHAR;
+    public static final OfByte int_least8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef __int_least16_t int_least16_t
      * }
      */
-    public static final OfShort int_least16_t = dlpack_h.C_SHORT;
+    public static final OfShort int_least16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef __int_least32_t int_least32_t
      * }
      */
-    public static final OfInt int_least32_t = dlpack_h.C_INT;
+    public static final OfInt int_least32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __int_least64_t int_least64_t
      * }
      */
-    public static final OfLong int_least64_t = dlpack_h.C_LONG;
+    public static final OfLong int_least64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __uint_least8_t uint_least8_t
      * }
      */
-    public static final OfByte uint_least8_t = dlpack_h.C_CHAR;
+    public static final OfByte uint_least8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef __uint_least16_t uint_least16_t
      * }
      */
-    public static final OfShort uint_least16_t = dlpack_h.C_SHORT;
+    public static final OfShort uint_least16_t = DlpackH.C_SHORT;
     /**
      * {@snippet lang=c :
      * typedef __uint_least32_t uint_least32_t
      * }
      */
-    public static final OfInt uint_least32_t = dlpack_h.C_INT;
+    public static final OfInt uint_least32_t = DlpackH.C_INT;
     /**
      * {@snippet lang=c :
      * typedef __uint_least64_t uint_least64_t
      * }
      */
-    public static final OfLong uint_least64_t = dlpack_h.C_LONG;
+    public static final OfLong uint_least64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef signed char int_fast8_t
      * }
      */
-    public static final OfByte int_fast8_t = dlpack_h.C_CHAR;
+    public static final OfByte int_fast8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef long int_fast16_t
      * }
      */
-    public static final OfLong int_fast16_t = dlpack_h.C_LONG;
+    public static final OfLong int_fast16_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long int_fast32_t
      * }
      */
-    public static final OfLong int_fast32_t = dlpack_h.C_LONG;
+    public static final OfLong int_fast32_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long int_fast64_t
      * }
      */
-    public static final OfLong int_fast64_t = dlpack_h.C_LONG;
+    public static final OfLong int_fast64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned char uint_fast8_t
      * }
      */
-    public static final OfByte uint_fast8_t = dlpack_h.C_CHAR;
+    public static final OfByte uint_fast8_t = DlpackH.C_CHAR;
     /**
      * {@snippet lang=c :
      * typedef unsigned long uint_fast16_t
      * }
      */
-    public static final OfLong uint_fast16_t = dlpack_h.C_LONG;
+    public static final OfLong uint_fast16_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long uint_fast32_t
      * }
      */
-    public static final OfLong uint_fast32_t = dlpack_h.C_LONG;
+    public static final OfLong uint_fast32_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long uint_fast64_t
      * }
      */
-    public static final OfLong uint_fast64_t = dlpack_h.C_LONG;
+    public static final OfLong uint_fast64_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long intptr_t
      * }
      */
-    public static final OfLong intptr_t = dlpack_h.C_LONG;
+    public static final OfLong intptr_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long uintptr_t
      * }
      */
-    public static final OfLong uintptr_t = dlpack_h.C_LONG;
+    public static final OfLong uintptr_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __intmax_t intmax_t
      * }
      */
-    public static final OfLong intmax_t = dlpack_h.C_LONG;
+    public static final OfLong intmax_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef __uintmax_t uintmax_t
      * }
      */
-    public static final OfLong uintmax_t = dlpack_h.C_LONG;
+    public static final OfLong uintmax_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef long ptrdiff_t
      * }
      */
-    public static final OfLong ptrdiff_t = dlpack_h.C_LONG;
+    public static final OfLong ptrdiff_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef unsigned long size_t
      * }
      */
-    public static final OfLong size_t = dlpack_h.C_LONG;
+    public static final OfLong size_t = DlpackH.C_LONG;
     /**
      * {@snippet lang=c :
      * typedef int wchar_t
      * }
      */
-    public static final OfInt wchar_t = dlpack_h.C_INT;
+    public static final OfInt wchar_t = DlpackH.C_INT;
     private static final int kDLCPU = (int)1L;
     /**
      * {@snippet lang=c :

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/Fsidt.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/Fsidt.java
@@ -17,31 +17,32 @@
 package com.nvidia.cuvs.panama;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.ValueLayout.OfLong;
+import java.lang.foreign.SequenceLayout;
+import java.lang.invoke.VarHandle;
 import java.util.function.Consumer;
 
 /**
  * {@snippet lang = c :
  * struct {
- *     uintptr_t addr;
- *     DLDataType dtype;
+ *     int __val[2];
  * }
  * }
  */
-public class CuvsHnswIndex {
+public class Fsidt {
 
-  CuvsHnswIndex() {
+  Fsidt() {
     // Should not be called directly
   }
 
-  private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(hnsw_h.C_LONG.withName("addr"),
-      DLDataType.layout().withName("dtype"), MemoryLayout.paddingLayout(4)).withName("$anon$66:9");
+  private static final GroupLayout $LAYOUT = MemoryLayout
+      .structLayout(MemoryLayout.sequenceLayout(2, CagraH.C_INT).withName("__val")).withName("$anon$155:12");
 
   /**
    * The layout of this struct
@@ -50,84 +51,75 @@ public class CuvsHnswIndex {
     return $LAYOUT;
   }
 
-  private static final OfLong addr$LAYOUT = (OfLong) $LAYOUT.select(groupElement("addr"));
+  private static final SequenceLayout __val$LAYOUT = (SequenceLayout) $LAYOUT.select(groupElement("__val"));
 
   /**
    * Layout for field:
-   * {@snippet lang = c : * uintptr_t addr
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static final OfLong addr$layout() {
-    return addr$LAYOUT;
+  public static final SequenceLayout __val$layout() {
+    return __val$LAYOUT;
   }
 
-  private static final long addr$OFFSET = 0;
+  private static final long __val$OFFSET = 0;
 
   /**
    * Offset for field:
-   * {@snippet lang = c : * uintptr_t addr
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static final long addr$offset() {
-    return addr$OFFSET;
+  public static final long __val$offset() {
+    return __val$OFFSET;
   }
 
   /**
    * Getter for field:
-   * {@snippet lang = c : * uintptr_t addr
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static long addr(MemorySegment struct) {
-    return struct.get(addr$LAYOUT, addr$OFFSET);
+  public static MemorySegment __val(MemorySegment struct) {
+    return struct.asSlice(__val$OFFSET, __val$LAYOUT.byteSize());
   }
 
   /**
    * Setter for field:
-   * {@snippet lang = c : * uintptr_t addr
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static void addr(MemorySegment struct, long fieldValue) {
-    struct.set(addr$LAYOUT, addr$OFFSET, fieldValue);
+  public static void __val(MemorySegment struct, MemorySegment fieldValue) {
+    MemorySegment.copy(fieldValue, 0L, struct, __val$OFFSET, __val$LAYOUT.byteSize());
   }
 
-  private static final GroupLayout dtype$LAYOUT = (GroupLayout) $LAYOUT.select(groupElement("dtype"));
+  private static long[] __val$DIMS = { 2 };
 
   /**
-   * Layout for field:
-   * {@snippet lang = c : * DLDataType dtype
+   * Dimensions for array field:
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static final GroupLayout dtype$layout() {
-    return dtype$LAYOUT;
+  public static long[] __val$dimensions() {
+    return __val$DIMS;
   }
 
-  private static final long dtype$OFFSET = 8;
+  private static final VarHandle __val$ELEM_HANDLE = __val$LAYOUT.varHandle(sequenceElement());
 
   /**
-   * Offset for field:
-   * {@snippet lang = c : * DLDataType dtype
+   * Indexed getter for field:
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static final long dtype$offset() {
-    return dtype$OFFSET;
-  }
-
-  /**
-   * Getter for field:
-   * {@snippet lang = c : * DLDataType dtype
-   * }
-   */
-  public static MemorySegment dtype(MemorySegment struct) {
-    return struct.asSlice(dtype$OFFSET, dtype$LAYOUT.byteSize());
+  public static int __val(MemorySegment struct, long index0) {
+    return (int) __val$ELEM_HANDLE.get(struct, 0L, index0);
   }
 
   /**
-   * Setter for field:
-   * {@snippet lang = c : * DLDataType dtype
+   * Indexed setter for field:
+   * {@snippet lang = c : * int __val[2]
    * }
    */
-  public static void dtype(MemorySegment struct, MemorySegment fieldValue) {
-    MemorySegment.copy(fieldValue, 0L, struct, dtype$OFFSET, dtype$LAYOUT.byteSize());
+  public static void __val(MemorySegment struct, long index0, int fieldValue) {
+    __val$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
   }
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/HnswH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/HnswH.java
@@ -39,9 +39,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class cagra_h {
+public class HnswH {
 
-  cagra_h() {
+  HnswH() {
     // Should not be called directly
   }
 
@@ -884,467 +884,467 @@ public class cagra_h {
    * {@snippet lang = c : * typedef unsigned char __u_char
    * }
    */
-  public static final OfByte __u_char = cagra_h.C_CHAR;
+  public static final OfByte __u_char = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned short __u_short
    * }
    */
-  public static final OfShort __u_short = cagra_h.C_SHORT;
+  public static final OfShort __u_short = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned int __u_int
    * }
    */
-  public static final OfInt __u_int = cagra_h.C_INT;
+  public static final OfInt __u_int = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_long
    * }
    */
-  public static final OfLong __u_long = cagra_h.C_LONG;
+  public static final OfLong __u_long = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char __int8_t
    * }
    */
-  public static final OfByte __int8_t = cagra_h.C_CHAR;
+  public static final OfByte __int8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned char __uint8_t
    * }
    */
-  public static final OfByte __uint8_t = cagra_h.C_CHAR;
+  public static final OfByte __uint8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef short __int16_t
    * }
    */
-  public static final OfShort __int16_t = cagra_h.C_SHORT;
+  public static final OfShort __int16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned short __uint16_t
    * }
    */
-  public static final OfShort __uint16_t = cagra_h.C_SHORT;
+  public static final OfShort __uint16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef int __int32_t
    * }
    */
-  public static final OfInt __int32_t = cagra_h.C_INT;
+  public static final OfInt __int32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __uint32_t
    * }
    */
-  public static final OfInt __uint32_t = cagra_h.C_INT;
+  public static final OfInt __uint32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __int64_t
    * }
    */
-  public static final OfLong __int64_t = cagra_h.C_LONG;
+  public static final OfLong __int64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uint64_t
    * }
    */
-  public static final OfLong __uint64_t = cagra_h.C_LONG;
+  public static final OfLong __uint64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int8_t __int_least8_t
    * }
    */
-  public static final OfByte __int_least8_t = cagra_h.C_CHAR;
+  public static final OfByte __int_least8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint8_t __uint_least8_t
    * }
    */
-  public static final OfByte __uint_least8_t = cagra_h.C_CHAR;
+  public static final OfByte __uint_least8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t __int_least16_t
    * }
    */
-  public static final OfShort __int_least16_t = cagra_h.C_SHORT;
+  public static final OfShort __int_least16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint16_t __uint_least16_t
    * }
    */
-  public static final OfShort __uint_least16_t = cagra_h.C_SHORT;
+  public static final OfShort __uint_least16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t __int_least32_t
    * }
    */
-  public static final OfInt __int_least32_t = cagra_h.C_INT;
+  public static final OfInt __int_least32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint32_t __uint_least32_t
    * }
    */
-  public static final OfInt __uint_least32_t = cagra_h.C_INT;
+  public static final OfInt __uint_least32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t __int_least64_t
    * }
    */
-  public static final OfLong __int_least64_t = cagra_h.C_LONG;
+  public static final OfLong __int_least64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint64_t __uint_least64_t
    * }
    */
-  public static final OfLong __uint_least64_t = cagra_h.C_LONG;
+  public static final OfLong __uint_least64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __quad_t
    * }
    */
-  public static final OfLong __quad_t = cagra_h.C_LONG;
+  public static final OfLong __quad_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_quad_t
    * }
    */
-  public static final OfLong __u_quad_t = cagra_h.C_LONG;
+  public static final OfLong __u_quad_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __intmax_t
    * }
    */
-  public static final OfLong __intmax_t = cagra_h.C_LONG;
+  public static final OfLong __intmax_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uintmax_t
    * }
    */
-  public static final OfLong __uintmax_t = cagra_h.C_LONG;
+  public static final OfLong __uintmax_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __dev_t
    * }
    */
-  public static final OfLong __dev_t = cagra_h.C_LONG;
+  public static final OfLong __dev_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __uid_t
    * }
    */
-  public static final OfInt __uid_t = cagra_h.C_INT;
+  public static final OfInt __uid_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __gid_t
    * }
    */
-  public static final OfInt __gid_t = cagra_h.C_INT;
+  public static final OfInt __gid_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino_t
    * }
    */
-  public static final OfLong __ino_t = cagra_h.C_LONG;
+  public static final OfLong __ino_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino64_t
    * }
    */
-  public static final OfLong __ino64_t = cagra_h.C_LONG;
+  public static final OfLong __ino64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __mode_t
    * }
    */
-  public static final OfInt __mode_t = cagra_h.C_INT;
+  public static final OfInt __mode_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __nlink_t
    * }
    */
-  public static final OfLong __nlink_t = cagra_h.C_LONG;
+  public static final OfLong __nlink_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off_t
    * }
    */
-  public static final OfLong __off_t = cagra_h.C_LONG;
+  public static final OfLong __off_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off64_t
    * }
    */
-  public static final OfLong __off64_t = cagra_h.C_LONG;
+  public static final OfLong __off64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __pid_t
    * }
    */
-  public static final OfInt __pid_t = cagra_h.C_INT;
+  public static final OfInt __pid_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __clock_t
    * }
    */
-  public static final OfLong __clock_t = cagra_h.C_LONG;
+  public static final OfLong __clock_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim_t
    * }
    */
-  public static final OfLong __rlim_t = cagra_h.C_LONG;
+  public static final OfLong __rlim_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim64_t
    * }
    */
-  public static final OfLong __rlim64_t = cagra_h.C_LONG;
+  public static final OfLong __rlim64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __id_t
    * }
    */
-  public static final OfInt __id_t = cagra_h.C_INT;
+  public static final OfInt __id_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __time_t
    * }
    */
-  public static final OfLong __time_t = cagra_h.C_LONG;
+  public static final OfLong __time_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __useconds_t
    * }
    */
-  public static final OfInt __useconds_t = cagra_h.C_INT;
+  public static final OfInt __useconds_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __suseconds_t
    * }
    */
-  public static final OfLong __suseconds_t = cagra_h.C_LONG;
+  public static final OfLong __suseconds_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __suseconds64_t
    * }
    */
-  public static final OfLong __suseconds64_t = cagra_h.C_LONG;
+  public static final OfLong __suseconds64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __daddr_t
    * }
    */
-  public static final OfInt __daddr_t = cagra_h.C_INT;
+  public static final OfInt __daddr_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __key_t
    * }
    */
-  public static final OfInt __key_t = cagra_h.C_INT;
+  public static final OfInt __key_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __clockid_t
    * }
    */
-  public static final OfInt __clockid_t = cagra_h.C_INT;
+  public static final OfInt __clockid_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef void *__timer_t
    * }
    */
-  public static final AddressLayout __timer_t = cagra_h.C_POINTER;
+  public static final AddressLayout __timer_t = HnswH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __blksize_t
    * }
    */
-  public static final OfLong __blksize_t = cagra_h.C_LONG;
+  public static final OfLong __blksize_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt_t
    * }
    */
-  public static final OfLong __blkcnt_t = cagra_h.C_LONG;
+  public static final OfLong __blkcnt_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt64_t
    * }
    */
-  public static final OfLong __blkcnt64_t = cagra_h.C_LONG;
+  public static final OfLong __blkcnt64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt_t
    * }
    */
-  public static final OfLong __fsblkcnt_t = cagra_h.C_LONG;
+  public static final OfLong __fsblkcnt_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt64_t
    * }
    */
-  public static final OfLong __fsblkcnt64_t = cagra_h.C_LONG;
+  public static final OfLong __fsblkcnt64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt_t
    * }
    */
-  public static final OfLong __fsfilcnt_t = cagra_h.C_LONG;
+  public static final OfLong __fsfilcnt_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt64_t
    * }
    */
-  public static final OfLong __fsfilcnt64_t = cagra_h.C_LONG;
+  public static final OfLong __fsfilcnt64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __fsword_t
    * }
    */
-  public static final OfLong __fsword_t = cagra_h.C_LONG;
+  public static final OfLong __fsword_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __ssize_t
    * }
    */
-  public static final OfLong __ssize_t = cagra_h.C_LONG;
+  public static final OfLong __ssize_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __syscall_slong_t
    * }
    */
-  public static final OfLong __syscall_slong_t = cagra_h.C_LONG;
+  public static final OfLong __syscall_slong_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __syscall_ulong_t
    * }
    */
-  public static final OfLong __syscall_ulong_t = cagra_h.C_LONG;
+  public static final OfLong __syscall_ulong_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __off64_t __loff_t
    * }
    */
-  public static final OfLong __loff_t = cagra_h.C_LONG;
+  public static final OfLong __loff_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef char *__caddr_t
    * }
    */
-  public static final AddressLayout __caddr_t = cagra_h.C_POINTER;
+  public static final AddressLayout __caddr_t = HnswH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __intptr_t
    * }
    */
-  public static final OfLong __intptr_t = cagra_h.C_LONG;
+  public static final OfLong __intptr_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __socklen_t
    * }
    */
-  public static final OfInt __socklen_t = cagra_h.C_INT;
+  public static final OfInt __socklen_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __sig_atomic_t
    * }
    */
-  public static final OfInt __sig_atomic_t = cagra_h.C_INT;
+  public static final OfInt __sig_atomic_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int8_t int8_t
    * }
    */
-  public static final OfByte int8_t = cagra_h.C_CHAR;
+  public static final OfByte int8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t int16_t
    * }
    */
-  public static final OfShort int16_t = cagra_h.C_SHORT;
+  public static final OfShort int16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t int32_t
    * }
    */
-  public static final OfInt int32_t = cagra_h.C_INT;
+  public static final OfInt int32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t int64_t
    * }
    */
-  public static final OfLong int64_t = cagra_h.C_LONG;
+  public static final OfLong int64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint8_t uint8_t
    * }
    */
-  public static final OfByte uint8_t = cagra_h.C_CHAR;
+  public static final OfByte uint8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint16_t uint16_t
    * }
    */
-  public static final OfShort uint16_t = cagra_h.C_SHORT;
+  public static final OfShort uint16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint32_t uint32_t
    * }
    */
-  public static final OfInt uint32_t = cagra_h.C_INT;
+  public static final OfInt uint32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint64_t uint64_t
    * }
    */
-  public static final OfLong uint64_t = cagra_h.C_LONG;
+  public static final OfLong uint64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int_least8_t int_least8_t
    * }
    */
-  public static final OfByte int_least8_t = cagra_h.C_CHAR;
+  public static final OfByte int_least8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int_least16_t int_least16_t
    * }
    */
-  public static final OfShort int_least16_t = cagra_h.C_SHORT;
+  public static final OfShort int_least16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int_least32_t int_least32_t
    * }
    */
-  public static final OfInt int_least32_t = cagra_h.C_INT;
+  public static final OfInt int_least32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int_least64_t int_least64_t
    * }
    */
-  public static final OfLong int_least64_t = cagra_h.C_LONG;
+  public static final OfLong int_least64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint_least8_t uint_least8_t
    * }
    */
-  public static final OfByte uint_least8_t = cagra_h.C_CHAR;
+  public static final OfByte uint_least8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint_least16_t uint_least16_t
    * }
    */
-  public static final OfShort uint_least16_t = cagra_h.C_SHORT;
+  public static final OfShort uint_least16_t = HnswH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint_least32_t uint_least32_t
    * }
    */
-  public static final OfInt uint_least32_t = cagra_h.C_INT;
+  public static final OfInt uint_least32_t = HnswH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint_least64_t uint_least64_t
    * }
    */
-  public static final OfLong uint_least64_t = cagra_h.C_LONG;
+  public static final OfLong uint_least64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char int_fast8_t
    * }
    */
-  public static final OfByte int_fast8_t = cagra_h.C_CHAR;
+  public static final OfByte int_fast8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef long int_fast16_t
    * }
    */
-  public static final OfLong int_fast16_t = cagra_h.C_LONG;
+  public static final OfLong int_fast16_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast32_t
    * }
    */
-  public static final OfLong int_fast32_t = cagra_h.C_LONG;
+  public static final OfLong int_fast32_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast64_t
    * }
    */
-  public static final OfLong int_fast64_t = cagra_h.C_LONG;
+  public static final OfLong int_fast64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned char uint_fast8_t
    * }
    */
-  public static final OfByte uint_fast8_t = cagra_h.C_CHAR;
+  public static final OfByte uint_fast8_t = HnswH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast16_t
    * }
    */
-  public static final OfLong uint_fast16_t = cagra_h.C_LONG;
+  public static final OfLong uint_fast16_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast32_t
    * }
    */
-  public static final OfLong uint_fast32_t = cagra_h.C_LONG;
+  public static final OfLong uint_fast32_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast64_t
    * }
    */
-  public static final OfLong uint_fast64_t = cagra_h.C_LONG;
+  public static final OfLong uint_fast64_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long intptr_t
    * }
    */
-  public static final OfLong intptr_t = cagra_h.C_LONG;
+  public static final OfLong intptr_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uintptr_t
    * }
    */
-  public static final OfLong uintptr_t = cagra_h.C_LONG;
+  public static final OfLong uintptr_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __intmax_t intmax_t
    * }
    */
-  public static final OfLong intmax_t = cagra_h.C_LONG;
+  public static final OfLong intmax_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uintmax_t uintmax_t
    * }
    */
-  public static final OfLong uintmax_t = cagra_h.C_LONG;
+  public static final OfLong uintmax_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long ptrdiff_t
    * }
    */
-  public static final OfLong ptrdiff_t = cagra_h.C_LONG;
+  public static final OfLong ptrdiff_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long size_t
    * }
    */
-  public static final OfLong size_t = cagra_h.C_LONG;
+  public static final OfLong size_t = HnswH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int wchar_t
    * }
    */
-  public static final OfInt wchar_t = cagra_h.C_INT;
+  public static final OfInt wchar_t = HnswH.C_INT;
   private static final int kDLCPU = (int) 1L;
 
   /**
@@ -1597,7 +1597,7 @@ public class cagra_h {
    * } *cuvsCagraCompressionParams_t
    * }
    */
-  public static final AddressLayout cuvsCagraCompressionParams_t = cagra_h.C_POINTER;
+  public static final AddressLayout cuvsCagraCompressionParams_t = HnswH.C_POINTER;
   /**
    * {@snippet lang = c :
    * typedef struct cuvsCagraIndexParams {
@@ -1610,7 +1610,7 @@ public class cagra_h {
    * } *cuvsCagraIndexParams_t
    * }
    */
-  public static final AddressLayout cuvsCagraIndexParams_t = cagra_h.C_POINTER;
+  public static final AddressLayout cuvsCagraIndexParams_t = HnswH.C_POINTER;
   private static final int SINGLE_CTA = (int) 0L;
 
   /**
@@ -1700,12 +1700,64 @@ public class cagra_h {
    * } *cuvsCagraSearchParams_t
    * }
    */
-  public static final AddressLayout cuvsCagraSearchParams_t = cagra_h.C_POINTER;
+  public static final AddressLayout cuvsCagraSearchParams_t = HnswH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef cuvsCagraIndex *cuvsCagraIndex_t
    * }
    */
-  public static final AddressLayout cuvsCagraIndex_t = cagra_h.C_POINTER;
+  public static final AddressLayout cuvsCagraIndex_t = HnswH.C_POINTER;
+  private static final int NONE = (int) 0L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsHnswHierarchy.NONE = 0
+   * }
+   */
+  public static int NONE() {
+    return NONE;
+  }
+
+  private static final int CPU = (int) 1L;
+
+  /**
+   * {@snippet lang = c : * enum cuvsHnswHierarchy.CPU = 1
+   * }
+   */
+  public static int CPU() {
+    return CPU;
+  }
+
+  /**
+   * {@snippet lang = c :
+   * typedef struct cuvsHnswIndexParams {
+   *     cuvsHnswHierarchy hierarchy;
+   *     int ef_construction;
+   *     int num_threads;
+   * } *cuvsHnswIndexParams_t
+   * }
+   */
+  public static final AddressLayout cuvsHnswIndexParams_t = HnswH.C_POINTER;
+  /**
+   * {@snippet lang = c : * typedef cuvsHnswIndex *cuvsHnswIndex_t
+   * }
+   */
+  public static final AddressLayout cuvsHnswIndex_t = HnswH.C_POINTER;
+  /**
+   * {@snippet lang = c :
+   * typedef struct cuvsHnswExtendParams {
+   *     int num_threads;
+   * } *cuvsHnswExtendParams_t
+   * }
+   */
+  public static final AddressLayout cuvsHnswExtendParams_t = HnswH.C_POINTER;
+  /**
+   * {@snippet lang = c :
+   * typedef struct cuvsHnswSearchParams {
+   *     int32_t ef;
+   *     int32_t num_threads;
+   * } *cuvsHnswSearchParams_t
+   * }
+   */
+  public static final AddressLayout cuvsHnswSearchParams_t = HnswH.C_POINTER;
   private static final long _POSIX_C_SOURCE = 200809L;
 
   /**

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/IvfFlatH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/IvfFlatH.java
@@ -39,9 +39,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class ivf_flat_h {
+public class IvfFlatH {
 
-  ivf_flat_h() {
+  IvfFlatH() {
     // Should not be called directly
   }
 
@@ -674,452 +674,452 @@ public class ivf_flat_h {
    * {@snippet lang = c : * typedef unsigned char __u_char
    * }
    */
-  public static final OfByte __u_char = ivf_flat_h.C_CHAR;
+  public static final OfByte __u_char = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned short __u_short
    * }
    */
-  public static final OfShort __u_short = ivf_flat_h.C_SHORT;
+  public static final OfShort __u_short = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned int __u_int
    * }
    */
-  public static final OfInt __u_int = ivf_flat_h.C_INT;
+  public static final OfInt __u_int = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_long
    * }
    */
-  public static final OfLong __u_long = ivf_flat_h.C_LONG;
+  public static final OfLong __u_long = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char __int8_t
    * }
    */
-  public static final OfByte __int8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte __int8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned char __uint8_t
    * }
    */
-  public static final OfByte __uint8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte __uint8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef short __int16_t
    * }
    */
-  public static final OfShort __int16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort __int16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned short __uint16_t
    * }
    */
-  public static final OfShort __uint16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort __uint16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef int __int32_t
    * }
    */
-  public static final OfInt __int32_t = ivf_flat_h.C_INT;
+  public static final OfInt __int32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __uint32_t
    * }
    */
-  public static final OfInt __uint32_t = ivf_flat_h.C_INT;
+  public static final OfInt __uint32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __int64_t
    * }
    */
-  public static final OfLong __int64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __int64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uint64_t
    * }
    */
-  public static final OfLong __uint64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __uint64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int8_t __int_least8_t
    * }
    */
-  public static final OfByte __int_least8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte __int_least8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint8_t __uint_least8_t
    * }
    */
-  public static final OfByte __uint_least8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte __uint_least8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t __int_least16_t
    * }
    */
-  public static final OfShort __int_least16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort __int_least16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint16_t __uint_least16_t
    * }
    */
-  public static final OfShort __uint_least16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort __uint_least16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t __int_least32_t
    * }
    */
-  public static final OfInt __int_least32_t = ivf_flat_h.C_INT;
+  public static final OfInt __int_least32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint32_t __uint_least32_t
    * }
    */
-  public static final OfInt __uint_least32_t = ivf_flat_h.C_INT;
+  public static final OfInt __uint_least32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t __int_least64_t
    * }
    */
-  public static final OfLong __int_least64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __int_least64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint64_t __uint_least64_t
    * }
    */
-  public static final OfLong __uint_least64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __uint_least64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __quad_t
    * }
    */
-  public static final OfLong __quad_t = ivf_flat_h.C_LONG;
+  public static final OfLong __quad_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_quad_t
    * }
    */
-  public static final OfLong __u_quad_t = ivf_flat_h.C_LONG;
+  public static final OfLong __u_quad_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __intmax_t
    * }
    */
-  public static final OfLong __intmax_t = ivf_flat_h.C_LONG;
+  public static final OfLong __intmax_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uintmax_t
    * }
    */
-  public static final OfLong __uintmax_t = ivf_flat_h.C_LONG;
+  public static final OfLong __uintmax_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __dev_t
    * }
    */
-  public static final OfLong __dev_t = ivf_flat_h.C_LONG;
+  public static final OfLong __dev_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __uid_t
    * }
    */
-  public static final OfInt __uid_t = ivf_flat_h.C_INT;
+  public static final OfInt __uid_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __gid_t
    * }
    */
-  public static final OfInt __gid_t = ivf_flat_h.C_INT;
+  public static final OfInt __gid_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino_t
    * }
    */
-  public static final OfLong __ino_t = ivf_flat_h.C_LONG;
+  public static final OfLong __ino_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino64_t
    * }
    */
-  public static final OfLong __ino64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __ino64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __mode_t
    * }
    */
-  public static final OfInt __mode_t = ivf_flat_h.C_INT;
+  public static final OfInt __mode_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __nlink_t
    * }
    */
-  public static final OfLong __nlink_t = ivf_flat_h.C_LONG;
+  public static final OfLong __nlink_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off_t
    * }
    */
-  public static final OfLong __off_t = ivf_flat_h.C_LONG;
+  public static final OfLong __off_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off64_t
    * }
    */
-  public static final OfLong __off64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __off64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __pid_t
    * }
    */
-  public static final OfInt __pid_t = ivf_flat_h.C_INT;
+  public static final OfInt __pid_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __clock_t
    * }
    */
-  public static final OfLong __clock_t = ivf_flat_h.C_LONG;
+  public static final OfLong __clock_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim_t
    * }
    */
-  public static final OfLong __rlim_t = ivf_flat_h.C_LONG;
+  public static final OfLong __rlim_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim64_t
    * }
    */
-  public static final OfLong __rlim64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __rlim64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __id_t
    * }
    */
-  public static final OfInt __id_t = ivf_flat_h.C_INT;
+  public static final OfInt __id_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __time_t
    * }
    */
-  public static final OfLong __time_t = ivf_flat_h.C_LONG;
+  public static final OfLong __time_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __useconds_t
    * }
    */
-  public static final OfInt __useconds_t = ivf_flat_h.C_INT;
+  public static final OfInt __useconds_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __suseconds_t
    * }
    */
-  public static final OfLong __suseconds_t = ivf_flat_h.C_LONG;
+  public static final OfLong __suseconds_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __suseconds64_t
    * }
    */
-  public static final OfLong __suseconds64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __suseconds64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __daddr_t
    * }
    */
-  public static final OfInt __daddr_t = ivf_flat_h.C_INT;
+  public static final OfInt __daddr_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __key_t
    * }
    */
-  public static final OfInt __key_t = ivf_flat_h.C_INT;
+  public static final OfInt __key_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __clockid_t
    * }
    */
-  public static final OfInt __clockid_t = ivf_flat_h.C_INT;
+  public static final OfInt __clockid_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef void *__timer_t
    * }
    */
-  public static final AddressLayout __timer_t = ivf_flat_h.C_POINTER;
+  public static final AddressLayout __timer_t = IvfFlatH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __blksize_t
    * }
    */
-  public static final OfLong __blksize_t = ivf_flat_h.C_LONG;
+  public static final OfLong __blksize_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt_t
    * }
    */
-  public static final OfLong __blkcnt_t = ivf_flat_h.C_LONG;
+  public static final OfLong __blkcnt_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt64_t
    * }
    */
-  public static final OfLong __blkcnt64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __blkcnt64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt_t
    * }
    */
-  public static final OfLong __fsblkcnt_t = ivf_flat_h.C_LONG;
+  public static final OfLong __fsblkcnt_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt64_t
    * }
    */
-  public static final OfLong __fsblkcnt64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __fsblkcnt64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt_t
    * }
    */
-  public static final OfLong __fsfilcnt_t = ivf_flat_h.C_LONG;
+  public static final OfLong __fsfilcnt_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt64_t
    * }
    */
-  public static final OfLong __fsfilcnt64_t = ivf_flat_h.C_LONG;
+  public static final OfLong __fsfilcnt64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __fsword_t
    * }
    */
-  public static final OfLong __fsword_t = ivf_flat_h.C_LONG;
+  public static final OfLong __fsword_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __ssize_t
    * }
    */
-  public static final OfLong __ssize_t = ivf_flat_h.C_LONG;
+  public static final OfLong __ssize_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __syscall_slong_t
    * }
    */
-  public static final OfLong __syscall_slong_t = ivf_flat_h.C_LONG;
+  public static final OfLong __syscall_slong_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __syscall_ulong_t
    * }
    */
-  public static final OfLong __syscall_ulong_t = ivf_flat_h.C_LONG;
+  public static final OfLong __syscall_ulong_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __off64_t __loff_t
    * }
    */
-  public static final OfLong __loff_t = ivf_flat_h.C_LONG;
+  public static final OfLong __loff_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef char *__caddr_t
    * }
    */
-  public static final AddressLayout __caddr_t = ivf_flat_h.C_POINTER;
+  public static final AddressLayout __caddr_t = IvfFlatH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __intptr_t
    * }
    */
-  public static final OfLong __intptr_t = ivf_flat_h.C_LONG;
+  public static final OfLong __intptr_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __socklen_t
    * }
    */
-  public static final OfInt __socklen_t = ivf_flat_h.C_INT;
+  public static final OfInt __socklen_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __sig_atomic_t
    * }
    */
-  public static final OfInt __sig_atomic_t = ivf_flat_h.C_INT;
+  public static final OfInt __sig_atomic_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int8_t int8_t
    * }
    */
-  public static final OfByte int8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte int8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t int16_t
    * }
    */
-  public static final OfShort int16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort int16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t int32_t
    * }
    */
-  public static final OfInt int32_t = ivf_flat_h.C_INT;
+  public static final OfInt int32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t int64_t
    * }
    */
-  public static final OfLong int64_t = ivf_flat_h.C_LONG;
+  public static final OfLong int64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint8_t uint8_t
    * }
    */
-  public static final OfByte uint8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte uint8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint16_t uint16_t
    * }
    */
-  public static final OfShort uint16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort uint16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint32_t uint32_t
    * }
    */
-  public static final OfInt uint32_t = ivf_flat_h.C_INT;
+  public static final OfInt uint32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint64_t uint64_t
    * }
    */
-  public static final OfLong uint64_t = ivf_flat_h.C_LONG;
+  public static final OfLong uint64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int_least8_t int_least8_t
    * }
    */
-  public static final OfByte int_least8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte int_least8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int_least16_t int_least16_t
    * }
    */
-  public static final OfShort int_least16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort int_least16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int_least32_t int_least32_t
    * }
    */
-  public static final OfInt int_least32_t = ivf_flat_h.C_INT;
+  public static final OfInt int_least32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int_least64_t int_least64_t
    * }
    */
-  public static final OfLong int_least64_t = ivf_flat_h.C_LONG;
+  public static final OfLong int_least64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint_least8_t uint_least8_t
    * }
    */
-  public static final OfByte uint_least8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte uint_least8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint_least16_t uint_least16_t
    * }
    */
-  public static final OfShort uint_least16_t = ivf_flat_h.C_SHORT;
+  public static final OfShort uint_least16_t = IvfFlatH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint_least32_t uint_least32_t
    * }
    */
-  public static final OfInt uint_least32_t = ivf_flat_h.C_INT;
+  public static final OfInt uint_least32_t = IvfFlatH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint_least64_t uint_least64_t
    * }
    */
-  public static final OfLong uint_least64_t = ivf_flat_h.C_LONG;
+  public static final OfLong uint_least64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char int_fast8_t
    * }
    */
-  public static final OfByte int_fast8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte int_fast8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef long int_fast16_t
    * }
    */
-  public static final OfLong int_fast16_t = ivf_flat_h.C_LONG;
+  public static final OfLong int_fast16_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast32_t
    * }
    */
-  public static final OfLong int_fast32_t = ivf_flat_h.C_LONG;
+  public static final OfLong int_fast32_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast64_t
    * }
    */
-  public static final OfLong int_fast64_t = ivf_flat_h.C_LONG;
+  public static final OfLong int_fast64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned char uint_fast8_t
    * }
    */
-  public static final OfByte uint_fast8_t = ivf_flat_h.C_CHAR;
+  public static final OfByte uint_fast8_t = IvfFlatH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast16_t
    * }
    */
-  public static final OfLong uint_fast16_t = ivf_flat_h.C_LONG;
+  public static final OfLong uint_fast16_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast32_t
    * }
    */
-  public static final OfLong uint_fast32_t = ivf_flat_h.C_LONG;
+  public static final OfLong uint_fast32_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast64_t
    * }
    */
-  public static final OfLong uint_fast64_t = ivf_flat_h.C_LONG;
+  public static final OfLong uint_fast64_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long intptr_t
    * }
    */
-  public static final OfLong intptr_t = ivf_flat_h.C_LONG;
+  public static final OfLong intptr_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uintptr_t
    * }
    */
-  public static final OfLong uintptr_t = ivf_flat_h.C_LONG;
+  public static final OfLong uintptr_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __intmax_t intmax_t
    * }
    */
-  public static final OfLong intmax_t = ivf_flat_h.C_LONG;
+  public static final OfLong intmax_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uintmax_t uintmax_t
    * }
    */
-  public static final OfLong uintmax_t = ivf_flat_h.C_LONG;
+  public static final OfLong uintmax_t = IvfFlatH.C_LONG;
   private static final int CUVS_ERROR = (int) 0L;
 
   /**
@@ -1144,7 +1144,7 @@ public class ivf_flat_h {
    * {@snippet lang = c : * typedef uintptr_t cuvsResources_t
    * }
    */
-  public static final OfLong cuvsResources_t = ivf_flat_h.C_LONG;
+  public static final OfLong cuvsResources_t = IvfFlatH.C_LONG;
   private static final int L2Expanded = (int) 0L;
 
   /**
@@ -1359,17 +1359,17 @@ public class ivf_flat_h {
    * {@snippet lang = c : * typedef long ptrdiff_t
    * }
    */
-  public static final OfLong ptrdiff_t = ivf_flat_h.C_LONG;
+  public static final OfLong ptrdiff_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long size_t
    * }
    */
-  public static final OfLong size_t = ivf_flat_h.C_LONG;
+  public static final OfLong size_t = IvfFlatH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int wchar_t
    * }
    */
-  public static final OfInt wchar_t = ivf_flat_h.C_INT;
+  public static final OfInt wchar_t = IvfFlatH.C_INT;
   private static final int kDLCPU = (int) 1L;
 
   /**
@@ -1604,12 +1604,12 @@ public class ivf_flat_h {
    * } *cuvsIvfFlatIndexParams_t
    * }
    */
-  public static final AddressLayout cuvsIvfFlatIndexParams_t = ivf_flat_h.C_POINTER;
+  public static final AddressLayout cuvsIvfFlatIndexParams_t = IvfFlatH.C_POINTER;
 
   private static class cuvsIvfFlatIndexParamsCreate {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatIndexParamsCreate");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatIndexParamsCreate");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1662,9 +1662,9 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatIndexParamsDestroy {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatIndexParamsDestroy");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatIndexParamsDestroy");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1723,12 +1723,12 @@ public class ivf_flat_h {
    * } *cuvsIvfFlatSearchParams_t
    * }
    */
-  public static final AddressLayout cuvsIvfFlatSearchParams_t = ivf_flat_h.C_POINTER;
+  public static final AddressLayout cuvsIvfFlatSearchParams_t = IvfFlatH.C_POINTER;
 
   private static class cuvsIvfFlatSearchParamsCreate {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatSearchParamsCreate");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatSearchParamsCreate");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1781,9 +1781,9 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatSearchParamsDestroy {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatSearchParamsDestroy");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatSearchParamsDestroy");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1839,12 +1839,12 @@ public class ivf_flat_h {
    * {@snippet lang = c : * typedef cuvsIvfFlatIndex *cuvsIvfFlatIndex_t
    * }
    */
-  public static final AddressLayout cuvsIvfFlatIndex_t = ivf_flat_h.C_POINTER;
+  public static final AddressLayout cuvsIvfFlatIndex_t = IvfFlatH.C_POINTER;
 
   private static class cuvsIvfFlatIndexCreate {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatIndexCreate");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatIndexCreate");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1897,9 +1897,9 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatIndexDestroy {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatIndexDestroy");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatIndexDestroy");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1952,10 +1952,10 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatBuild {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_LONG,
-        ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_LONG,
+        IvfFlatH.C_POINTER, IvfFlatH.C_POINTER, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatBuild");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatBuild");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2008,10 +2008,10 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatSearch {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_LONG,
-        ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_LONG,
+        IvfFlatH.C_POINTER, IvfFlatH.C_POINTER, IvfFlatH.C_POINTER, IvfFlatH.C_POINTER, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatSearch");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatSearch");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2065,10 +2065,10 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatSerialize {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_LONG,
-        ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_LONG,
+        IvfFlatH.C_POINTER, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatSerialize");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatSerialize");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2121,10 +2121,10 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatDeserialize {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_LONG,
-        ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_LONG,
+        IvfFlatH.C_POINTER, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatDeserialize");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatDeserialize");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2177,10 +2177,10 @@ public class ivf_flat_h {
   }
 
   private static class cuvsIvfFlatExtend {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_flat_h.C_INT, ivf_flat_h.C_LONG,
-        ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER, ivf_flat_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfFlatH.C_INT, IvfFlatH.C_LONG,
+        IvfFlatH.C_POINTER, IvfFlatH.C_POINTER, IvfFlatH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_flat_h.findOrThrow("cuvsIvfFlatExtend");
+    public static final MemorySegment ADDR = IvfFlatH.findOrThrow("cuvsIvfFlatExtend");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/IvfPqH.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/IvfPqH.java
@@ -39,9 +39,9 @@ import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-public class ivf_pq_h {
+public class IvfPqH {
 
-  ivf_pq_h() {
+  IvfPqH() {
     // Should not be called directly
   }
 
@@ -674,452 +674,452 @@ public class ivf_pq_h {
    * {@snippet lang = c : * typedef unsigned char __u_char
    * }
    */
-  public static final OfByte __u_char = ivf_pq_h.C_CHAR;
+  public static final OfByte __u_char = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned short __u_short
    * }
    */
-  public static final OfShort __u_short = ivf_pq_h.C_SHORT;
+  public static final OfShort __u_short = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned int __u_int
    * }
    */
-  public static final OfInt __u_int = ivf_pq_h.C_INT;
+  public static final OfInt __u_int = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_long
    * }
    */
-  public static final OfLong __u_long = ivf_pq_h.C_LONG;
+  public static final OfLong __u_long = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char __int8_t
    * }
    */
-  public static final OfByte __int8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte __int8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned char __uint8_t
    * }
    */
-  public static final OfByte __uint8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte __uint8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef short __int16_t
    * }
    */
-  public static final OfShort __int16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort __int16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef unsigned short __uint16_t
    * }
    */
-  public static final OfShort __uint16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort __uint16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef int __int32_t
    * }
    */
-  public static final OfInt __int32_t = ivf_pq_h.C_INT;
+  public static final OfInt __int32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __uint32_t
    * }
    */
-  public static final OfInt __uint32_t = ivf_pq_h.C_INT;
+  public static final OfInt __uint32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __int64_t
    * }
    */
-  public static final OfLong __int64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __int64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uint64_t
    * }
    */
-  public static final OfLong __uint64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __uint64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int8_t __int_least8_t
    * }
    */
-  public static final OfByte __int_least8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte __int_least8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint8_t __uint_least8_t
    * }
    */
-  public static final OfByte __uint_least8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte __uint_least8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t __int_least16_t
    * }
    */
-  public static final OfShort __int_least16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort __int_least16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint16_t __uint_least16_t
    * }
    */
-  public static final OfShort __uint_least16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort __uint_least16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t __int_least32_t
    * }
    */
-  public static final OfInt __int_least32_t = ivf_pq_h.C_INT;
+  public static final OfInt __int_least32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint32_t __uint_least32_t
    * }
    */
-  public static final OfInt __uint_least32_t = ivf_pq_h.C_INT;
+  public static final OfInt __uint_least32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t __int_least64_t
    * }
    */
-  public static final OfLong __int_least64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __int_least64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint64_t __uint_least64_t
    * }
    */
-  public static final OfLong __uint_least64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __uint_least64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __quad_t
    * }
    */
-  public static final OfLong __quad_t = ivf_pq_h.C_LONG;
+  public static final OfLong __quad_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __u_quad_t
    * }
    */
-  public static final OfLong __u_quad_t = ivf_pq_h.C_LONG;
+  public static final OfLong __u_quad_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __intmax_t
    * }
    */
-  public static final OfLong __intmax_t = ivf_pq_h.C_LONG;
+  public static final OfLong __intmax_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __uintmax_t
    * }
    */
-  public static final OfLong __uintmax_t = ivf_pq_h.C_LONG;
+  public static final OfLong __uintmax_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __dev_t
    * }
    */
-  public static final OfLong __dev_t = ivf_pq_h.C_LONG;
+  public static final OfLong __dev_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __uid_t
    * }
    */
-  public static final OfInt __uid_t = ivf_pq_h.C_INT;
+  public static final OfInt __uid_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned int __gid_t
    * }
    */
-  public static final OfInt __gid_t = ivf_pq_h.C_INT;
+  public static final OfInt __gid_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino_t
    * }
    */
-  public static final OfLong __ino_t = ivf_pq_h.C_LONG;
+  public static final OfLong __ino_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __ino64_t
    * }
    */
-  public static final OfLong __ino64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __ino64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __mode_t
    * }
    */
-  public static final OfInt __mode_t = ivf_pq_h.C_INT;
+  public static final OfInt __mode_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef unsigned long __nlink_t
    * }
    */
-  public static final OfLong __nlink_t = ivf_pq_h.C_LONG;
+  public static final OfLong __nlink_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off_t
    * }
    */
-  public static final OfLong __off_t = ivf_pq_h.C_LONG;
+  public static final OfLong __off_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __off64_t
    * }
    */
-  public static final OfLong __off64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __off64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __pid_t
    * }
    */
-  public static final OfInt __pid_t = ivf_pq_h.C_INT;
+  public static final OfInt __pid_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __clock_t
    * }
    */
-  public static final OfLong __clock_t = ivf_pq_h.C_LONG;
+  public static final OfLong __clock_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim_t
    * }
    */
-  public static final OfLong __rlim_t = ivf_pq_h.C_LONG;
+  public static final OfLong __rlim_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __rlim64_t
    * }
    */
-  public static final OfLong __rlim64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __rlim64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __id_t
    * }
    */
-  public static final OfInt __id_t = ivf_pq_h.C_INT;
+  public static final OfInt __id_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __time_t
    * }
    */
-  public static final OfLong __time_t = ivf_pq_h.C_LONG;
+  public static final OfLong __time_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __useconds_t
    * }
    */
-  public static final OfInt __useconds_t = ivf_pq_h.C_INT;
+  public static final OfInt __useconds_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef long __suseconds_t
    * }
    */
-  public static final OfLong __suseconds_t = ivf_pq_h.C_LONG;
+  public static final OfLong __suseconds_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __suseconds64_t
    * }
    */
-  public static final OfLong __suseconds64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __suseconds64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int __daddr_t
    * }
    */
-  public static final OfInt __daddr_t = ivf_pq_h.C_INT;
+  public static final OfInt __daddr_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __key_t
    * }
    */
-  public static final OfInt __key_t = ivf_pq_h.C_INT;
+  public static final OfInt __key_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __clockid_t
    * }
    */
-  public static final OfInt __clockid_t = ivf_pq_h.C_INT;
+  public static final OfInt __clockid_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef void *__timer_t
    * }
    */
-  public static final AddressLayout __timer_t = ivf_pq_h.C_POINTER;
+  public static final AddressLayout __timer_t = IvfPqH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __blksize_t
    * }
    */
-  public static final OfLong __blksize_t = ivf_pq_h.C_LONG;
+  public static final OfLong __blksize_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt_t
    * }
    */
-  public static final OfLong __blkcnt_t = ivf_pq_h.C_LONG;
+  public static final OfLong __blkcnt_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __blkcnt64_t
    * }
    */
-  public static final OfLong __blkcnt64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __blkcnt64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt_t
    * }
    */
-  public static final OfLong __fsblkcnt_t = ivf_pq_h.C_LONG;
+  public static final OfLong __fsblkcnt_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsblkcnt64_t
    * }
    */
-  public static final OfLong __fsblkcnt64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __fsblkcnt64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt_t
    * }
    */
-  public static final OfLong __fsfilcnt_t = ivf_pq_h.C_LONG;
+  public static final OfLong __fsfilcnt_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __fsfilcnt64_t
    * }
    */
-  public static final OfLong __fsfilcnt64_t = ivf_pq_h.C_LONG;
+  public static final OfLong __fsfilcnt64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __fsword_t
    * }
    */
-  public static final OfLong __fsword_t = ivf_pq_h.C_LONG;
+  public static final OfLong __fsword_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __ssize_t
    * }
    */
-  public static final OfLong __ssize_t = ivf_pq_h.C_LONG;
+  public static final OfLong __ssize_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long __syscall_slong_t
    * }
    */
-  public static final OfLong __syscall_slong_t = ivf_pq_h.C_LONG;
+  public static final OfLong __syscall_slong_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long __syscall_ulong_t
    * }
    */
-  public static final OfLong __syscall_ulong_t = ivf_pq_h.C_LONG;
+  public static final OfLong __syscall_ulong_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __off64_t __loff_t
    * }
    */
-  public static final OfLong __loff_t = ivf_pq_h.C_LONG;
+  public static final OfLong __loff_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef char *__caddr_t
    * }
    */
-  public static final AddressLayout __caddr_t = ivf_pq_h.C_POINTER;
+  public static final AddressLayout __caddr_t = IvfPqH.C_POINTER;
   /**
    * {@snippet lang = c : * typedef long __intptr_t
    * }
    */
-  public static final OfLong __intptr_t = ivf_pq_h.C_LONG;
+  public static final OfLong __intptr_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned int __socklen_t
    * }
    */
-  public static final OfInt __socklen_t = ivf_pq_h.C_INT;
+  public static final OfInt __socklen_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef int __sig_atomic_t
    * }
    */
-  public static final OfInt __sig_atomic_t = ivf_pq_h.C_INT;
+  public static final OfInt __sig_atomic_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int8_t int8_t
    * }
    */
-  public static final OfByte int8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte int8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int16_t int16_t
    * }
    */
-  public static final OfShort int16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort int16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int32_t int32_t
    * }
    */
-  public static final OfInt int32_t = ivf_pq_h.C_INT;
+  public static final OfInt int32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int64_t int64_t
    * }
    */
-  public static final OfLong int64_t = ivf_pq_h.C_LONG;
+  public static final OfLong int64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint8_t uint8_t
    * }
    */
-  public static final OfByte uint8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte uint8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint16_t uint16_t
    * }
    */
-  public static final OfShort uint16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort uint16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint32_t uint32_t
    * }
    */
-  public static final OfInt uint32_t = ivf_pq_h.C_INT;
+  public static final OfInt uint32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint64_t uint64_t
    * }
    */
-  public static final OfLong uint64_t = ivf_pq_h.C_LONG;
+  public static final OfLong uint64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __int_least8_t int_least8_t
    * }
    */
-  public static final OfByte int_least8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte int_least8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __int_least16_t int_least16_t
    * }
    */
-  public static final OfShort int_least16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort int_least16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __int_least32_t int_least32_t
    * }
    */
-  public static final OfInt int_least32_t = ivf_pq_h.C_INT;
+  public static final OfInt int_least32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __int_least64_t int_least64_t
    * }
    */
-  public static final OfLong int_least64_t = ivf_pq_h.C_LONG;
+  public static final OfLong int_least64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uint_least8_t uint_least8_t
    * }
    */
-  public static final OfByte uint_least8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte uint_least8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef __uint_least16_t uint_least16_t
    * }
    */
-  public static final OfShort uint_least16_t = ivf_pq_h.C_SHORT;
+  public static final OfShort uint_least16_t = IvfPqH.C_SHORT;
   /**
    * {@snippet lang = c : * typedef __uint_least32_t uint_least32_t
    * }
    */
-  public static final OfInt uint_least32_t = ivf_pq_h.C_INT;
+  public static final OfInt uint_least32_t = IvfPqH.C_INT;
   /**
    * {@snippet lang = c : * typedef __uint_least64_t uint_least64_t
    * }
    */
-  public static final OfLong uint_least64_t = ivf_pq_h.C_LONG;
+  public static final OfLong uint_least64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef signed char int_fast8_t
    * }
    */
-  public static final OfByte int_fast8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte int_fast8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef long int_fast16_t
    * }
    */
-  public static final OfLong int_fast16_t = ivf_pq_h.C_LONG;
+  public static final OfLong int_fast16_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast32_t
    * }
    */
-  public static final OfLong int_fast32_t = ivf_pq_h.C_LONG;
+  public static final OfLong int_fast32_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long int_fast64_t
    * }
    */
-  public static final OfLong int_fast64_t = ivf_pq_h.C_LONG;
+  public static final OfLong int_fast64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned char uint_fast8_t
    * }
    */
-  public static final OfByte uint_fast8_t = ivf_pq_h.C_CHAR;
+  public static final OfByte uint_fast8_t = IvfPqH.C_CHAR;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast16_t
    * }
    */
-  public static final OfLong uint_fast16_t = ivf_pq_h.C_LONG;
+  public static final OfLong uint_fast16_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast32_t
    * }
    */
-  public static final OfLong uint_fast32_t = ivf_pq_h.C_LONG;
+  public static final OfLong uint_fast32_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uint_fast64_t
    * }
    */
-  public static final OfLong uint_fast64_t = ivf_pq_h.C_LONG;
+  public static final OfLong uint_fast64_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef long intptr_t
    * }
    */
-  public static final OfLong intptr_t = ivf_pq_h.C_LONG;
+  public static final OfLong intptr_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long uintptr_t
    * }
    */
-  public static final OfLong uintptr_t = ivf_pq_h.C_LONG;
+  public static final OfLong uintptr_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __intmax_t intmax_t
    * }
    */
-  public static final OfLong intmax_t = ivf_pq_h.C_LONG;
+  public static final OfLong intmax_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef __uintmax_t uintmax_t
    * }
    */
-  public static final OfLong uintmax_t = ivf_pq_h.C_LONG;
+  public static final OfLong uintmax_t = IvfPqH.C_LONG;
   private static final int CUVS_ERROR = (int) 0L;
 
   /**
@@ -1144,7 +1144,7 @@ public class ivf_pq_h {
    * {@snippet lang = c : * typedef uintptr_t cuvsResources_t
    * }
    */
-  public static final OfLong cuvsResources_t = ivf_pq_h.C_LONG;
+  public static final OfLong cuvsResources_t = IvfPqH.C_LONG;
   private static final int L2Expanded = (int) 0L;
 
   /**
@@ -1359,17 +1359,17 @@ public class ivf_pq_h {
    * {@snippet lang = c : * typedef long ptrdiff_t
    * }
    */
-  public static final OfLong ptrdiff_t = ivf_pq_h.C_LONG;
+  public static final OfLong ptrdiff_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef unsigned long size_t
    * }
    */
-  public static final OfLong size_t = ivf_pq_h.C_LONG;
+  public static final OfLong size_t = IvfPqH.C_LONG;
   /**
    * {@snippet lang = c : * typedef int wchar_t
    * }
    */
-  public static final OfInt wchar_t = ivf_pq_h.C_INT;
+  public static final OfInt wchar_t = IvfPqH.C_INT;
   private static final int kDLCPU = (int) 1L;
 
   /**
@@ -1938,12 +1938,12 @@ public class ivf_pq_h {
    * } *cuvsIvfPqIndexParams_t
    * }
    */
-  public static final AddressLayout cuvsIvfPqIndexParams_t = ivf_pq_h.C_POINTER;
+  public static final AddressLayout cuvsIvfPqIndexParams_t = IvfPqH.C_POINTER;
 
   private static class cuvsIvfPqIndexParamsCreate {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqIndexParamsCreate");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqIndexParamsCreate");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -1996,9 +1996,9 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqIndexParamsDestroy {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqIndexParamsDestroy");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqIndexParamsDestroy");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2060,12 +2060,12 @@ public class ivf_pq_h {
    * } *cuvsIvfPqSearchParams_t
    * }
    */
-  public static final AddressLayout cuvsIvfPqSearchParams_t = ivf_pq_h.C_POINTER;
+  public static final AddressLayout cuvsIvfPqSearchParams_t = IvfPqH.C_POINTER;
 
   private static class cuvsIvfPqSearchParamsCreate {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqSearchParamsCreate");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqSearchParamsCreate");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2118,9 +2118,9 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqSearchParamsDestroy {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqSearchParamsDestroy");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqSearchParamsDestroy");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2176,12 +2176,12 @@ public class ivf_pq_h {
    * {@snippet lang = c : * typedef cuvsIvfPq *cuvsIvfPqIndex_t
    * }
    */
-  public static final AddressLayout cuvsIvfPqIndex_t = ivf_pq_h.C_POINTER;
+  public static final AddressLayout cuvsIvfPqIndex_t = IvfPqH.C_POINTER;
 
   private static class cuvsIvfPqIndexCreate {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqIndexCreate");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqIndexCreate");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2234,9 +2234,9 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqIndexDestroy {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqIndexDestroy");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqIndexDestroy");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2289,10 +2289,10 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqBuild {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_LONG,
-        ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_LONG,
+        IvfPqH.C_POINTER, IvfPqH.C_POINTER, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqBuild");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqBuild");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2345,10 +2345,10 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqSearch {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_LONG,
-        ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_LONG,
+        IvfPqH.C_POINTER, IvfPqH.C_POINTER, IvfPqH.C_POINTER, IvfPqH.C_POINTER, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqSearch");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqSearch");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2402,10 +2402,10 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqSerialize {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_LONG,
-        ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_LONG,
+        IvfPqH.C_POINTER, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqSerialize");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqSerialize");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2458,10 +2458,10 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqDeserialize {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_LONG,
-        ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_LONG,
+        IvfPqH.C_POINTER, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqDeserialize");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqDeserialize");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }
@@ -2514,10 +2514,10 @@ public class ivf_pq_h {
   }
 
   private static class cuvsIvfPqExtend {
-    public static final FunctionDescriptor DESC = FunctionDescriptor.of(ivf_pq_h.C_INT, ivf_pq_h.C_LONG,
-        ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER, ivf_pq_h.C_POINTER);
+    public static final FunctionDescriptor DESC = FunctionDescriptor.of(IvfPqH.C_INT, IvfPqH.C_LONG,
+        IvfPqH.C_POINTER, IvfPqH.C_POINTER, IvfPqH.C_POINTER);
 
-    public static final MemorySegment ADDR = ivf_pq_h.findOrThrow("cuvsIvfPqExtend");
+    public static final MemorySegment ADDR = IvfPqH.findOrThrow("cuvsIvfPqExtend");
 
     public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
   }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/MaxAlignT.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/panama/MaxAlignT.java
@@ -23,29 +23,27 @@ import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
-import java.lang.foreign.ValueLayout.OfInt;
 import java.lang.foreign.ValueLayout.OfLong;
 import java.util.function.Consumer;
 
 /**
  * {@snippet lang=c :
  * struct {
- *     uintptr_t addr;
- *     enum cuvsFilterType type;
+ *     long long __clang_max_align_nonce1;
+ *     long double __clang_max_align_nonce2;
  * }
  * }
  */
-public class cuvsFilter {
+public class MaxAlignT {
 
-    cuvsFilter() {
+    MaxAlignT() {
         // Should not be called directly
     }
 
     private static final GroupLayout $LAYOUT = MemoryLayout.structLayout(
-        brute_force_h.C_LONG.withName("addr"),
-        brute_force_h.C_INT.withName("type"),
-        MemoryLayout.paddingLayout(4)
-    ).withName("$anon$50:9");
+        DlpackH.C_LONG_LONG.withName("__clang_max_align_nonce1"),
+        MemoryLayout.paddingLayout(24)
+    ).withName("$anon$19:9");
 
     /**
      * The layout of this struct
@@ -54,92 +52,48 @@ public class cuvsFilter {
         return $LAYOUT;
     }
 
-    private static final OfLong addr$LAYOUT = (OfLong)$LAYOUT.select(groupElement("addr"));
+    private static final OfLong __clang_max_align_nonce1$LAYOUT = (OfLong)$LAYOUT.select(groupElement("__clang_max_align_nonce1"));
 
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * uintptr_t addr
+     * long long __clang_max_align_nonce1
      * }
      */
-    public static final OfLong addr$layout() {
-        return addr$LAYOUT;
+    public static final OfLong __clang_max_align_nonce1$layout() {
+        return __clang_max_align_nonce1$LAYOUT;
     }
 
-    private static final long addr$OFFSET = 0;
+    private static final long __clang_max_align_nonce1$OFFSET = 0;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * uintptr_t addr
+     * long long __clang_max_align_nonce1
      * }
      */
-    public static final long addr$offset() {
-        return addr$OFFSET;
+    public static final long __clang_max_align_nonce1$offset() {
+        return __clang_max_align_nonce1$OFFSET;
     }
 
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * uintptr_t addr
+     * long long __clang_max_align_nonce1
      * }
      */
-    public static long addr(MemorySegment struct) {
-        return struct.get(addr$LAYOUT, addr$OFFSET);
+    public static long __clang_max_align_nonce1(MemorySegment struct) {
+        return struct.get(__clang_max_align_nonce1$LAYOUT, __clang_max_align_nonce1$OFFSET);
     }
 
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * uintptr_t addr
+     * long long __clang_max_align_nonce1
      * }
      */
-    public static void addr(MemorySegment struct, long fieldValue) {
-        struct.set(addr$LAYOUT, addr$OFFSET, fieldValue);
-    }
-
-    private static final OfInt type$LAYOUT = (OfInt)$LAYOUT.select(groupElement("type"));
-
-    /**
-     * Layout for field:
-     * {@snippet lang=c :
-     * enum cuvsFilterType type
-     * }
-     */
-    public static final OfInt type$layout() {
-        return type$LAYOUT;
-    }
-
-    private static final long type$OFFSET = 8;
-
-    /**
-     * Offset for field:
-     * {@snippet lang=c :
-     * enum cuvsFilterType type
-     * }
-     */
-    public static final long type$offset() {
-        return type$OFFSET;
-    }
-
-    /**
-     * Getter for field:
-     * {@snippet lang=c :
-     * enum cuvsFilterType type
-     * }
-     */
-    public static int type(MemorySegment struct) {
-        return struct.get(type$LAYOUT, type$OFFSET);
-    }
-
-    /**
-     * Setter for field:
-     * {@snippet lang=c :
-     * enum cuvsFilterType type
-     * }
-     */
-    public static void type(MemorySegment struct, int fieldValue) {
-        struct.set(type$LAYOUT, type$OFFSET, fieldValue);
+    public static void __clang_max_align_nonce1(MemorySegment struct, long fieldValue) {
+        struct.set(__clang_max_align_nonce1$LAYOUT, __clang_max_align_nonce1$OFFSET, fieldValue);
     }
 
     /**

--- a/java/cuvs-java/src/main/java/module-info.java
+++ b/java/cuvs-java/src/main/java/module-info.java
@@ -15,7 +15,5 @@
  */
 
 module com.nvidia.cuvs {
-  //requires org.apache.commons.io;
-
   exports com.nvidia.cuvs;
 }

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -434,10 +434,8 @@ void get_gpu_info(int *return_value, int num_gpus, int *gpu_id, long *free_memor
   size_t free, total;
   for (int i = 0; i < num_gpus; i++) {
     cudaSetDevice(i);
-    int id;
-    cudaGetDevice(&id);
     cudaMemGetInfo(&free, &total);
-    *(gpu_id + i) = id;
+    *(gpu_id + i) = i;
     *(free_memory + i) = free;
     *(total_memory + i) = total;
   }

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -415,3 +415,30 @@ void search_hnsw_index(cuvsResources_t cuvs_resources, cuvsHnswIndex_t hnsw_inde
 void destroy_hnsw_index(cuvsHnswIndex_t hnsw_index, int *return_value) {
   *return_value = cuvsHnswIndexDestroy(hnsw_index);
 }
+
+/**
+ * @brief A function to get the number of GPUs
+ * 
+ * @param[out] return_value return value for cudaGetDeviceCount function call
+ * @param[out] num_gpus the number of GPUs detected
+ */
+void get_num_gpus(int *return_value, int *num_gpus) {
+  *return_value = cudaGetDeviceCount(num_gpus);
+}
+
+/**
+ * @brief A function to get GPU details
+ * 
+ */
+void get_gpu_info(int *return_value, int num_gpus, int *gpu_id, long *free_memory, long *total_memory) {
+  size_t free, total;
+  for (int i = 0; i < num_gpus; i++) {
+    cudaSetDevice(i);
+    int id;
+    cudaGetDevice(&id);
+    cudaMemGetInfo(&free, &total);
+    *(gpu_id + i) = id;
+    *(free_memory + i) = free;
+    *(total_memory + i) = total;
+  }
+}


### PR DESCRIPTION
This PR introduces a feature to get the GPU count and additional information in the API. 
GPU information (id, free memory, and total memory) is encapsulated in `GPUInfo`.
In addition to the feature, the code change invokes a lightweight `getNumGPUs` when creating an instance of `CuVSResources`. If a GPU is not found, this will raise a `GPUException`.