### PR TITLE
Feature: get GPU information

### DIFF
--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
@@ -78,7 +78,7 @@ public class CuVSResources implements AutoCloseable {
     getGpuInfoMethodHandle = linker.downcallHandle(symbolLookup.find("get_gpu_info").get(), FunctionDescriptor
         .ofVoid(ValueLayout.ADDRESS, intMemoryLayout, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
-    getNumGPUs(); // To check if GPUs can be found to proceed.
+    getNumGPUs(); // To check if GPUs are found before proceeding.
     createResources();
   }
 
@@ -87,7 +87,7 @@ public class CuVSResources implements AutoCloseable {
    * 
    * @return the number of GPUs on the machine
    */
-  public int getNumGPUs() throws Throwable {
+  protected int getNumGPUs() throws Throwable {
     MemoryLayout returnValueMemoryLayout = intMemoryLayout;
     MemorySegment returnValueMemorySegment = arena.allocate(returnValueMemoryLayout);
 
@@ -110,8 +110,8 @@ public class CuVSResources implements AutoCloseable {
     case 100: // cudaErrorNoDevice
       throw new GPUException("No CUDA-capable devices were detected by the installed CUDA driver");
     default:
-      throw new GPUException("Return value: " + returnValue
-          + " Please find details here: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3f51e3575c2178246db0a94a430e0038");
+      throw new GPUException("Returned value: " + returnValue
+          + " Please find more details here: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3f51e3575c2178246db0a94a430e0038");
     }
   }
 
@@ -120,7 +120,7 @@ public class CuVSResources implements AutoCloseable {
    * 
    * @return a list of {@link GPUInfo} objects with GPU details
    */
-  public List<GPUInfo> getGPUInfo() throws Throwable {
+  protected List<GPUInfo> getGPUInfo() throws Throwable {
     int numGPUs = getNumGPUs();
     List<GPUInfo> results = new ArrayList<GPUInfo>();
     MemoryLayout returnValueMemoryLayout = intMemoryLayout;
@@ -194,7 +194,7 @@ public class CuVSResources implements AutoCloseable {
   /**
    * Container for GPU information
    */
-  public class GPUInfo {
+  protected class GPUInfo {
 
     private int gpuId;
     private long freeMemory;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
@@ -21,10 +21,15 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SequenceLayout;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.nvidia.cuvs.common.Util;
 
@@ -41,8 +46,11 @@ public class CuVSResources implements AutoCloseable {
   protected File nativeLibrary;
   private final MethodHandle createResourcesMethodHandle;
   private final MethodHandle destroyResourcesMethodHandle;
+  private final MethodHandle getGpuInfoMethodHandle;
+  private final MethodHandle getNumGpusMethodHandle;
   private MemorySegment resourcesMemorySegment;
   private MemoryLayout intMemoryLayout;
+  private MemoryLayout longMemoryLayout;
 
   /**
    * Constructor that allocates the resources needed for cuVS
@@ -56,6 +64,7 @@ public class CuVSResources implements AutoCloseable {
     nativeLibrary = Util.loadLibraryFromJar("/libcuvs_java.so");
     symbolLookup = SymbolLookup.libraryLookup(nativeLibrary.getAbsolutePath(), arena);
     intMemoryLayout = linker.canonicalLayouts().get("int");
+    longMemoryLayout = linker.canonicalLayouts().get("long");
 
     createResourcesMethodHandle = linker.downcallHandle(symbolLookup.find("create_resources").get(),
         FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
@@ -63,7 +72,83 @@ public class CuVSResources implements AutoCloseable {
     destroyResourcesMethodHandle = linker.downcallHandle(symbolLookup.find("destroy_resources").get(),
         FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
+    getNumGpusMethodHandle = linker.downcallHandle(symbolLookup.find("get_num_gpus").get(),
+        FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+    getGpuInfoMethodHandle = linker.downcallHandle(symbolLookup.find("get_gpu_info").get(), FunctionDescriptor
+        .ofVoid(ValueLayout.ADDRESS, intMemoryLayout, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+    if (getNumGPUs() == 0)
+      throw new GPUException("No GPUs found! The CuVS Java API needs GPU to work.");
+
     createResources();
+  }
+
+  /**
+   * Gets the number of GPUs on the machine
+   * 
+   * @return the number of GPUs on the machine
+   */
+  public int getNumGPUs() throws Throwable {
+    MemoryLayout returnValueMemoryLayout = intMemoryLayout;
+    MemorySegment returnValueMemorySegment = arena.allocate(returnValueMemoryLayout);
+
+    MemoryLayout numGPUsMemoryLayout = intMemoryLayout;
+    MemorySegment numGPUsMemorySegment = arena.allocate(numGPUsMemoryLayout);
+
+    getNumGpusMethodHandle.invokeExact(returnValueMemorySegment, numGPUsMemorySegment);
+    int returnValue = returnValueMemorySegment.get(ValueLayout.JAVA_INT, 0);
+
+    switch (returnValue) {
+    case 0: // cudaSuccess
+      return numGPUsMemorySegment.get(ValueLayout.JAVA_INT, 0);
+    case 3: // cudaErrorInitializationError
+      throw new GPUException("The API call failed because the CUDA driver and runtime could not be initialized.");
+    case 35: // cudaErrorInsufficientDriver
+      throw new GPUException("The installed NVIDIA CUDA driver is older than the CUDA runtime library");
+    case 100: // cudaErrorNoDevice
+      throw new GPUException("No CUDA-capable devices were detected by the installed CUDA driver");
+    default:
+      throw new GPUException("Return value: " + returnValue
+          + " Please find details here: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3f51e3575c2178246db0a94a430e0038");
+    }
+  }
+
+  /**
+   * Gets the GPU information
+   * 
+   * @return a list of {@link GPUInfo} objects with GPU details
+   */
+  public List<GPUInfo> getGPUInfo() throws Throwable {
+    int numGPUs = getNumGPUs();
+    List<GPUInfo> results = new ArrayList<GPUInfo>();
+    MemoryLayout returnValueMemoryLayout = intMemoryLayout;
+    MemorySegment returnValueMemorySegment = arena.allocate(returnValueMemoryLayout);
+
+    SequenceLayout gpuIdSequenceLayout = MemoryLayout.sequenceLayout(numGPUs, intMemoryLayout);
+    MemorySegment gpuIdMemorySegment = arena.allocate(gpuIdSequenceLayout);
+
+    SequenceLayout freeMemSequenceLayout = MemoryLayout.sequenceLayout(numGPUs, longMemoryLayout);
+    MemorySegment freeMemMemorySegment = arena.allocate(freeMemSequenceLayout);
+
+    SequenceLayout totalMemSequenceLayout = MemoryLayout.sequenceLayout(numGPUs, longMemoryLayout);
+    MemorySegment totalMemMemorySegment = arena.allocate(totalMemSequenceLayout);
+
+    getGpuInfoMethodHandle.invokeExact(returnValueMemorySegment, numGPUs, gpuIdMemorySegment, freeMemMemorySegment,
+        totalMemMemorySegment);
+
+    VarHandle gpuIdVarHandle = gpuIdSequenceLayout.varHandle(PathElement.sequenceElement());
+    VarHandle freeMemVarHandle = freeMemSequenceLayout.varHandle(PathElement.sequenceElement());
+    VarHandle totalMemVarHandle = totalMemSequenceLayout.varHandle(PathElement.sequenceElement());
+
+    for (int i = 0; i < numGPUs; i++) {
+      int gpuId = (int) gpuIdVarHandle.get(gpuIdMemorySegment, 0L, i);
+      long freeMemory = (long) freeMemVarHandle.get(freeMemMemorySegment, 0L, i);
+      long totalMemory = (long) totalMemVarHandle.get(totalMemMemorySegment, 0L, i);
+      results.add(new GPUInfo(gpuId, freeMemory, totalMemory));
+    }
+
+    return results;
   }
 
   /**
@@ -105,4 +190,37 @@ public class CuVSResources implements AutoCloseable {
     return symbolLookup;
   }
 
+  /**
+   * Container for GPU information
+   */
+  public class GPUInfo {
+
+    private int gpuId;
+    private long freeMemory;
+    private long totalMemory;
+
+    public GPUInfo(int gpuId, long freeMemory, long totalMemory) {
+      super();
+      this.gpuId = gpuId;
+      this.freeMemory = freeMemory;
+      this.totalMemory = totalMemory;
+    }
+
+    public int getGpuId() {
+      return gpuId;
+    }
+
+    public long getFreeMemory() {
+      return freeMemory;
+    }
+
+    public long getTotalMemory() {
+      return totalMemory;
+    }
+
+    @Override
+    public String toString() {
+      return "GPUInfo [gpuId=" + gpuId + ", freeMemory=" + freeMemory + ", totalMemory=" + totalMemory + "]";
+    }
+  }
 }

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CuVSResources.java
@@ -78,9 +78,7 @@ public class CuVSResources implements AutoCloseable {
     getGpuInfoMethodHandle = linker.downcallHandle(symbolLookup.find("get_gpu_info").get(), FunctionDescriptor
         .ofVoid(ValueLayout.ADDRESS, intMemoryLayout, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
-    if (getNumGPUs() == 0)
-      throw new GPUException("No GPUs found! The CuVS Java API needs GPU to work.");
-
+    getNumGPUs(); // To check if GPUs can be found to proceed.
     createResources();
   }
 
@@ -101,7 +99,10 @@ public class CuVSResources implements AutoCloseable {
 
     switch (returnValue) {
     case 0: // cudaSuccess
-      return numGPUsMemorySegment.get(ValueLayout.JAVA_INT, 0);
+      int result = numGPUsMemorySegment.get(ValueLayout.JAVA_INT, 0);
+      if (result == 0)
+        throw new GPUException("No GPUs found! The CuVS Java API needs GPU to work.");
+      return result;
     case 3: // cudaErrorInitializationError
       throw new GPUException("The API call failed because the CUDA driver and runtime could not be initialized.");
     case 35: // cudaErrorInsufficientDriver

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/GPUException.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/GPUException.java
@@ -1,0 +1,14 @@
+package com.nvidia.cuvs;
+
+public class GPUException extends RuntimeException {
+
+	private static final long serialVersionUID = 4406787247551929480L;
+	
+	public GPUException(Exception ex) {
+		super (ex);
+	}
+
+	public GPUException(String message) {
+		super (message);
+	}
+}

--- a/java/cuvs-java/src/main/java/module-info.java
+++ b/java/cuvs-java/src/main/java/module-info.java
@@ -15,7 +15,5 @@
  */
 
 module com.nvidia.cuvs {
-  //requires org.apache.commons.io;
-
   exports com.nvidia.cuvs;
 }

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -429,12 +429,17 @@ void get_num_gpus(int *return_value, int *num_gpus) {
 /**
  * @brief A function to get GPU details
  * 
+ * @param[out] return_value return value for cudaGetDeviceCount function call
+ * @param[in] num_gpus the count of gpus passed to expect details on
+ * @param[out] gpu_id an integer array of gpu ids returned
+ * @param[out] free_memory an array of free memory (free_memory[n] for gpu[n]; 0 <= n <= (cudaGetDeviceCount() - 1))
+ * @param[out] total_memory an array of total memory (total_memory[n] for gpu[n]; 0 <= n <= (cudaGetDeviceCount() - 1))
  */
 void get_gpu_info(int *return_value, int num_gpus, int *gpu_id, long *free_memory, long *total_memory) {
   size_t free, total;
   for (int i = 0; i < num_gpus; i++) {
     cudaSetDevice(i);
-    cudaMemGetInfo(&free, &total);
+    *return_value = cudaMemGetInfo(&free, &total);
     *(gpu_id + i) = i;
     *(free_memory + i) = free;
     *(total_memory + i) = total;

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -429,7 +429,7 @@ void get_num_gpus(int *return_value, int *num_gpus) {
 /**
  * @brief A function to get GPU details
  * 
- * @param[out] return_value return value for cudaGetDeviceCount function call
+ * @param[out] return_value return value for cudaMemGetInfo function call
  * @param[in] num_gpus the count of gpus passed to expect details on
  * @param[out] gpu_id an integer array of gpu ids returned
  * @param[out] free_memory an array of free memory (free_memory[n] for gpu[n]; 0 <= n <= (cudaGetDeviceCount() - 1))

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -432,8 +432,8 @@ void get_num_gpus(int *return_value, int *num_gpus) {
  * @param[out] return_value return value for cudaMemGetInfo function call
  * @param[in] num_gpus the count of gpus passed to expect details on
  * @param[out] gpu_id an integer array of gpu ids returned
- * @param[out] free_memory an array of free memory (free_memory[n] for gpu[n]; 0 <= n <= (cudaGetDeviceCount() - 1))
- * @param[out] total_memory an array of total memory (total_memory[n] for gpu[n]; 0 <= n <= (cudaGetDeviceCount() - 1))
+ * @param[out] free_memory an array of free memory values (free_memory[n] for gpu[n] where 0 <= n <= (cudaGetDeviceCount() - 1))
+ * @param[out] total_memory an array of total memory values (total_memory[n] for gpu[n] where 0 <= n <= (cudaGetDeviceCount() - 1))
  */
 void get_gpu_info(int *return_value, int num_gpus, int *gpu_id, long *free_memory, long *total_memory) {
   size_t free, total;

--- a/java/internal/src/cuvs_java.c
+++ b/java/internal/src/cuvs_java.c
@@ -415,3 +415,28 @@ void search_hnsw_index(cuvsResources_t cuvs_resources, cuvsHnswIndex_t hnsw_inde
 void destroy_hnsw_index(cuvsHnswIndex_t hnsw_index, int *return_value) {
   *return_value = cuvsHnswIndexDestroy(hnsw_index);
 }
+
+/**
+ * @brief A function to get the number of GPUs
+ * 
+ * @param[out] return_value return value for cudaGetDeviceCount function call
+ * @param[out] num_gpus the number of GPUs detected
+ */
+void get_num_gpus(int *return_value, int *num_gpus) {
+  *return_value = cudaGetDeviceCount(num_gpus);
+}
+
+/**
+ * @brief A function to get GPU details
+ * 
+ */
+void get_gpu_info(int *return_value, int num_gpus, int *gpu_id, long *free_memory, long *total_memory) {
+  size_t free, total;
+  for (int i = 0; i < num_gpus; i++) {
+    cudaSetDevice(i);
+    cudaMemGetInfo(&free, &total);
+    *(gpu_id + i) = i;
+    *(free_memory + i) = free;
+    *(total_memory + i) = total;
+  }
+}


### PR DESCRIPTION
This PR introduces a feature to get the GPU count and additional information in the API. 

GPU information (id, free memory, and total memory) is encapsulated in `GPUInfo`.
In addition to the feature, the code change invokes a lightweight `getNumGPUs` when creating an instance of `CuVSResources`. If a GPU is not found, this will raise a `GPUException`.