### PR TITLE
Refactor method handle usage and separate out local areas from long held

### DIFF
--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraCompressionParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraCompressionParams.java
@@ -70,7 +70,7 @@ public class CagraCompressionParams {
    * Allocates the configured compression parameters in the MemorySegment.
    */
   private MemorySegment initMemorySegment() {
-    MemorySegment compressionParamsMemorySegment = CuVSCagraCompressionParams.allocate(resources.arena);
+    MemorySegment compressionParamsMemorySegment = CuVSCagraCompressionParams.allocate(resources.getArena());
     CuVSCagraCompressionParams.pq_bits(compressionParamsMemorySegment, pqBits);
     CuVSCagraCompressionParams.pq_dim(compressionParamsMemorySegment, pqDim);
     CuVSCagraCompressionParams.vq_n_centers(compressionParamsMemorySegment, vqNCenters);

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraIndexParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraIndexParams.java
@@ -179,7 +179,7 @@ public class CagraIndexParams {
   }
 
   private MemorySegment initMemorySegment() {
-    MemorySegment indexParamsMemorySegment = CuVSCagraIndexParams.allocate(resources.arena);
+    MemorySegment indexParamsMemorySegment = CuVSCagraIndexParams.allocate(resources.getArena());
     CuVSCagraIndexParams.intermediate_graph_degree(indexParamsMemorySegment, intermediateGraphDegree);
     CuVSCagraIndexParams.graph_degree(indexParamsMemorySegment, graphDegree);
     CuVSCagraIndexParams.build_algo(indexParamsMemorySegment, cuvsCagraGraphBuildAlgo.value);

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraSearchParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/CagraSearchParams.java
@@ -152,7 +152,7 @@ public class CagraSearchParams {
    * Allocates the configured search parameters in the MemorySegment.
    */
   private MemorySegment allocateMemorySegment() {
-    MemorySegment memorySegment = CuVSCagraSearchParams.allocate(resources.arena);
+    MemorySegment memorySegment = CuVSCagraSearchParams.allocate(resources.getArena());
     CuVSCagraSearchParams.max_queries(memorySegment, maxQueries);
     CuVSCagraSearchParams.itopk_size(memorySegment, iTopKSize);
     CuVSCagraSearchParams.max_iterations(memorySegment, maxIterations);

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswIndexParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswIndexParams.java
@@ -76,7 +76,7 @@ public class HnswIndexParams {
    * Allocates the configured search parameters in the MemorySegment.
    */
   private MemorySegment allocateMemorySegment() {
-    MemorySegment memorySegment = CuVSHnswIndexParams.allocate(resources.arena);
+    MemorySegment memorySegment = CuVSHnswIndexParams.allocate(resources.getArena());
     CuVSHnswIndexParams.ef_construction(memorySegment, efConstruction);
     CuVSHnswIndexParams.num_threads(memorySegment, numThreads);
     return memorySegment;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswSearchParams.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/HnswSearchParams.java
@@ -52,7 +52,7 @@ public class HnswSearchParams {
    * Allocates the configured search parameters in the MemorySegment.
    */
   private MemorySegment allocateMemorySegment() {
-    MemorySegment memorySegment = CuVSHnswSearchParams.allocate(resources.arena);
+    MemorySegment memorySegment = CuVSHnswSearchParams.allocate(resources.getArena());
     CuVSHnswSearchParams.ef(memorySegment, ef);
     CuVSHnswSearchParams.num_threads(memorySegment, numThreads);
     return memorySegment;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/LinkerHelper.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/LinkerHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.cuvs.common;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Utility methods for calling into the native linker.
+ */
+public class LinkerHelper {
+
+  private static final Linker LINKER = Linker.nativeLinker();
+  private static final SymbolLookup SYMBOL_LOOKUP;
+
+  public static final ValueLayout.OfByte C_CHAR = (ValueLayout.OfByte) LINKER.canonicalLayouts().get("char");
+
+  public static final ValueLayout.OfInt C_INT = (ValueLayout.OfInt) LINKER.canonicalLayouts().get("int");
+
+  public static final ValueLayout.OfLong C_LONG = (ValueLayout.OfLong) LINKER.canonicalLayouts().get("long");
+
+  public static final ValueLayout.OfFloat C_FLOAT = (ValueLayout.OfFloat) LINKER.canonicalLayouts().get("float");
+
+  static {
+    var nativeLibrary = LoaderUtils.loadNativeLibrary();
+    // we use a global arena here, since the symbols obtained
+    // from the returned lookup are for the lifetime of the jvm
+    SYMBOL_LOOKUP = SymbolLookup.libraryLookup(nativeLibrary.getAbsolutePath(), Arena.global());
+  }
+
+  static MemorySegment functionAddress(String function) {
+    return SYMBOL_LOOKUP.find(function).orElseThrow(() -> new LinkageError("Native function " + function + " could not be found"));
+  }
+
+  public static MethodHandle downcallHandle(String function, FunctionDescriptor functionDescriptor, Linker.Option... options) {
+    return LINKER.downcallHandle(functionAddress(function), functionDescriptor, options);
+  }
+
+  private LinkerHelper() {}
+}

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/LoaderUtils.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/LoaderUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.cuvs.common;
+
+import com.nvidia.cuvs.LibraryException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Objects;
+
+class LoaderUtils {
+
+  private LoaderUtils() {}
+
+  /**
+   * Load the CuVS .so file from environment variable CUVS_JAVA_SO_PATH. If not
+   * found there, try to load it from the classpath to a temporary file.
+   */
+  static File loadNativeLibrary() throws LibraryException {
+    String libraryPathFromEnvironment = System.getenv("CUVS_JAVA_SO_PATH");
+    if (libraryPathFromEnvironment != null) {
+      File file = new File(libraryPathFromEnvironment);
+      if (!file.exists()) {
+        throw new LibraryException(
+          "Environment variable CUVS_JAVA_SO_PATH points to non-existent file: " + libraryPathFromEnvironment);
+      }
+      return file;
+    }
+    return loadLibraryFromJar("/libcuvs_java.so");
+  }
+
+  static File loadLibraryFromJar(String path) throws LibraryException {
+    if (!path.startsWith("/")) {
+      throw new IllegalArgumentException("The path has to be absolute (start with '/').");
+    }
+    // Obtain filename from path
+    String[] parts = path.split("/");
+    String filename = (parts.length > 1) ? parts[parts.length - 1] : null;
+
+    // Split filename to prefix and suffix (extension)
+    String prefix = "";
+    String suffix = null;
+    if (filename != null) {
+      parts = filename.split("\\.", 2);
+      prefix = parts[0];
+      suffix = (parts.length > 1) ? "." + parts[parts.length - 1] : null;
+    }
+    // Prepare temporary file
+    try {
+      File temp = File.createTempFile(prefix, suffix);
+      InputStream libraryStream = Util.class.getModule().getResourceAsStream(path); // Util.class.getResourceAsStream(path);
+      if (libraryStream == null) {
+        throw new LibraryException("CuVS Library Not Found in ClassPath");
+      }
+      streamCopy(libraryStream, new FileOutputStream(temp));
+      return temp;
+    } catch (IOException ioe) {
+      throw new LibraryException(ioe);
+    }
+  }
+
+  static void streamCopy(InputStream is, OutputStream os) throws IOException {
+    Objects.requireNonNull(is);
+    try (var in = is;
+         var out = os) {
+      in.transferTo(out);
+    }
+  }
+}

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/SearchResults.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/SearchResults.java
@@ -12,8 +12,7 @@ public abstract class SearchResults {
 
   protected final List<Map<Integer, Float>> results;
   protected final List<Integer> mapping; // TODO: Is this performant in a user application?
-  protected final SequenceLayout neighboursSequenceLayout;
-  protected final SequenceLayout distancesSequenceLayout;
+
   protected final MemorySegment neighboursMemorySegment;
   protected final MemorySegment distancesMemorySegment;
   protected final int topK;
@@ -26,8 +25,6 @@ public abstract class SearchResults {
       long numberOfQueries) {
     this.topK = topK;
     this.numberOfQueries = numberOfQueries;
-    this.neighboursSequenceLayout = neighboursSequenceLayout;
-    this.distancesSequenceLayout = distancesSequenceLayout;
     this.neighboursMemorySegment = neighboursMemorySegment;
     this.distancesMemorySegment = distancesMemorySegment;
     this.mapping = mapping;

--- a/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/Util.java
+++ b/java/cuvs-java/src/main/java/com/nvidia/cuvs/common/Util.java
@@ -16,18 +16,11 @@
 
 package com.nvidia.cuvs.common;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemoryLayout.PathElement;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
@@ -35,29 +28,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.nvidia.cuvs.GPUInfo;
-import com.nvidia.cuvs.LibraryException;
 import com.nvidia.cuvs.panama.GpuInfo;
+
+import static com.nvidia.cuvs.common.LinkerHelper.C_CHAR;
+import static com.nvidia.cuvs.common.LinkerHelper.C_FLOAT;
+import static com.nvidia.cuvs.common.LinkerHelper.C_INT;
+import static com.nvidia.cuvs.common.LinkerHelper.C_LONG;
+import static com.nvidia.cuvs.common.LinkerHelper.downcallHandle;
+import static java.lang.foreign.ValueLayout.ADDRESS;
 
 public class Util {
 
-  private static Arena arena = null;
-  private static Linker linker = null;
-  private static SymbolLookup symbolLookup = null;
-  private static MemoryLayout intMemoryLayout;
-  private static MethodHandle getGpuInfoMethodHandle = null;
-  protected static File nativeLibrary;
+  public static final int CUVS_SUCCESS = 1;
 
-  static {
-    try {
-      linker = Linker.nativeLinker();
-      arena = Arena.ofShared();
-      nativeLibrary = Util.loadLibraryFromJar("/libcuvs_java.so");
-      symbolLookup = SymbolLookup.libraryLookup(nativeLibrary.getAbsolutePath(), arena);
-      intMemoryLayout = linker.canonicalLayouts().get("int");
-      getGpuInfoMethodHandle = linker.downcallHandle(symbolLookup.find("get_gpu_info").get(),
-          FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
-    } catch (Exception e) {
-      throw new LibraryException("LibCuVS Java Library Not Loaded", e);
+  private static final MethodHandle getGpuInfoMethodHandle = downcallHandle("get_gpu_info",
+          FunctionDescriptor.ofVoid(ADDRESS, ADDRESS, ADDRESS));
+
+  private Util() {}
+
+  /**
+   * Checks the result value of a native method handle call.
+   *
+   * @param value the return value
+   * @param caller the native method handle that was called
+   */
+  public static void checkError(int value, String caller) {
+    if (value != CUVS_SUCCESS) {
+      // TODO: handle error
+      throw new AssertionError(caller + " returned " + value);
     }
   }
 
@@ -96,44 +94,44 @@ public class Util {
    * @return a list of {@link GPUInfo} objects with GPU details
    */
   public static List<GPUInfo> availableGPUs() throws Throwable {
-    List<GPUInfo> results = new ArrayList<GPUInfo>();
-    MemoryLayout returnValueMemoryLayout = intMemoryLayout;
-    MemorySegment returnValueMemorySegment = arena.allocate(returnValueMemoryLayout);
-    MemoryLayout numGpuMemoryLayout = intMemoryLayout;
-    MemorySegment numGpuMemorySegment = arena.allocate(numGpuMemoryLayout);
+    List<GPUInfo> results = new ArrayList<>();
+    try (var localArena = Arena.ofConfined()) {
+      MemorySegment returnValueMemorySegment = localArena.allocate(C_INT);
+      MemorySegment numGpuMemorySegment = localArena.allocate(C_INT);
 
-    /*
-     * Setting a value of 1024 because we cannot predict how much memory to allocate
-     * before the function is invoked as cudaGetDeviceCount is inside the
-     * get_gpu_info function.
-     */
-    MemorySegment GpuInfoArrayMemorySegment = GpuInfo.allocateArray(1024, arena);
-    getGpuInfoMethodHandle.invokeExact(returnValueMemorySegment, numGpuMemorySegment, GpuInfoArrayMemorySegment);
-    int numGPUs = numGpuMemorySegment.get(ValueLayout.JAVA_INT, 0);
-    MemoryLayout ml = MemoryLayout.sequenceLayout(numGPUs, GpuInfo.layout());
-    for (int i = 0; i < numGPUs; i++) {
-      VarHandle gpuIdVarHandle = ml.varHandle(PathElement.sequenceElement(i), PathElement.groupElement("gpu_id"));
-      VarHandle freeMemoryVarHandle = ml.varHandle(PathElement.sequenceElement(i),
-          PathElement.groupElement("free_memory"));
-      VarHandle totalMemoryVarHandle = ml.varHandle(PathElement.sequenceElement(i),
-          PathElement.groupElement("total_memory"));
-      VarHandle ComputeCapabilityVarHandle = ml.varHandle(PathElement.sequenceElement(i),
-          PathElement.groupElement("compute_capability"));
-      StringBuilder gpuName = new StringBuilder();
-      char b = 1;
-      int p = 0;
-      while (b != 0x00) {
-        VarHandle gpuNameVarHandle = ml.varHandle(PathElement.sequenceElement(i), PathElement.groupElement("name"),
-            PathElement.sequenceElement(p++));
-        b = (char) (byte) gpuNameVarHandle.get(GpuInfoArrayMemorySegment, 0L);
-        gpuName.append(b);
+      /*
+       * Setting a value of 1024 because we cannot predict how much memory to allocate
+       * before the function is invoked as cudaGetDeviceCount is inside the
+       * get_gpu_info function.
+       */
+      MemorySegment GpuInfoArrayMemorySegment = GpuInfo.allocateArray(1024, localArena);
+      getGpuInfoMethodHandle.invokeExact(returnValueMemorySegment, numGpuMemorySegment, GpuInfoArrayMemorySegment);
+      int numGPUs = numGpuMemorySegment.get(ValueLayout.JAVA_INT, 0);
+      MemoryLayout ml = MemoryLayout.sequenceLayout(numGPUs, GpuInfo.layout());
+      for (int i = 0; i < numGPUs; i++) {
+        VarHandle gpuIdVarHandle = ml.varHandle(PathElement.sequenceElement(i), PathElement.groupElement("gpu_id"));
+        VarHandle freeMemoryVarHandle = ml.varHandle(PathElement.sequenceElement(i),
+                PathElement.groupElement("free_memory"));
+        VarHandle totalMemoryVarHandle = ml.varHandle(PathElement.sequenceElement(i),
+                PathElement.groupElement("total_memory"));
+        VarHandle ComputeCapabilityVarHandle = ml.varHandle(PathElement.sequenceElement(i),
+                PathElement.groupElement("compute_capability"));
+        StringBuilder gpuName = new StringBuilder();
+        char b = 1;
+        int p = 0;
+        while (b != 0x00) {
+          VarHandle gpuNameVarHandle = ml.varHandle(PathElement.sequenceElement(i), PathElement.groupElement("name"),
+                  PathElement.sequenceElement(p++));
+          b = (char) (byte) gpuNameVarHandle.get(GpuInfoArrayMemorySegment, 0L);
+          gpuName.append(b);
+        }
+        results.add(new GPUInfo((int) gpuIdVarHandle.get(GpuInfoArrayMemorySegment, 0L), gpuName.toString().trim(),
+                (long) freeMemoryVarHandle.get(GpuInfoArrayMemorySegment, 0L),
+                (long) totalMemoryVarHandle.get(GpuInfoArrayMemorySegment, 0L),
+                (float) ComputeCapabilityVarHandle.get(GpuInfoArrayMemorySegment, 0L)));
       }
-      results.add(new GPUInfo((int) gpuIdVarHandle.get(GpuInfoArrayMemorySegment, 0L), gpuName.toString().trim(),
-          (long) freeMemoryVarHandle.get(GpuInfoArrayMemorySegment, 0L),
-          (long) totalMemoryVarHandle.get(GpuInfoArrayMemorySegment, 0L),
-          (float) ComputeCapabilityVarHandle.get(GpuInfoArrayMemorySegment, 0L)));
+      return results;
     }
-    return results;
   }
 
   /**
@@ -143,10 +141,9 @@ public class Util {
    * @param str the string for the expected {@link MemorySegment}
    * @return an instance of {@link MemorySegment}
    */
-  public static MemorySegment buildMemorySegment(Linker linker, Arena arena, String str) {
-    MemoryLayout charMemoryLayout = linker.canonicalLayouts().get("char");
+  public static MemorySegment buildMemorySegment(Arena arena, String str) {
     StringBuilder sb = new StringBuilder(str).append('\0');
-    MemoryLayout stringMemoryLayout = MemoryLayout.sequenceLayout(sb.length(), charMemoryLayout);
+    MemoryLayout stringMemoryLayout = MemoryLayout.sequenceLayout(sb.length(), C_CHAR);
     MemorySegment stringMemorySegment = arena.allocate(stringMemoryLayout);
 
     for (int i = 0; i < sb.length(); i++) {
@@ -162,12 +159,11 @@ public class Util {
    * @param data The 1D long array for which the {@link MemorySegment} is needed
    * @return an instance of {@link MemorySegment}
    */
-  public static MemorySegment buildMemorySegment(Linker linker, Arena arena, long[] data) {
+  public static MemorySegment buildMemorySegment(Arena arena, long[] data) {
     int cells = data.length;
-    MemoryLayout longMemoryLayout = linker.canonicalLayouts().get("long");
-    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(cells, longMemoryLayout);
+    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(cells, C_LONG);
     MemorySegment dataMemorySegment = arena.allocate(dataMemoryLayout);
-    MemorySegment.copy(data, 0, dataMemorySegment, (ValueLayout) longMemoryLayout, 0, cells);
+    MemorySegment.copy(data, 0, dataMemorySegment, C_LONG, 0, cells);
     return dataMemorySegment;
   }
 
@@ -177,89 +173,15 @@ public class Util {
    * @param data The 2D float array for which the {@link MemorySegment} is needed
    * @return an instance of {@link MemorySegment}
    */
-  public static MemorySegment buildMemorySegment(Linker linker, Arena arena, float[][] data) {
+  public static MemorySegment buildMemorySegment(Arena arena, float[][] data) {
     long rows = data.length;
     long cols = rows > 0 ? data[0].length : 0;
-    MemoryLayout floatMemoryLayout = linker.canonicalLayouts().get("float");
-    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(rows * cols, floatMemoryLayout);
+    MemoryLayout dataMemoryLayout = MemoryLayout.sequenceLayout(rows * cols, C_FLOAT);
     MemorySegment dataMemorySegment = arena.allocate(dataMemoryLayout);
-    long floatByteSize = floatMemoryLayout.byteSize();
-
     for (int r = 0; r < rows; r++) {
-      MemorySegment.copy(data[r], 0, dataMemorySegment, (ValueLayout) floatMemoryLayout, (r * cols * floatByteSize),
+      MemorySegment.copy(data[r], 0, dataMemorySegment, (ValueLayout) C_FLOAT, (r * cols * C_FLOAT.byteSize()),
           (int) cols);
     }
-
     return dataMemorySegment;
-  }
-
-  /**
-   * Load the CuVS .so file from environment variable CUVS_JAVA_SO_PATH. If not
-   * found there, try to load it from the classpath to a temporary file.
-   */
-  public static File loadNativeLibrary() throws IOException {
-    String libraryPathFromEnvironment = System.getenv("CUVS_JAVA_SO_PATH");
-    if (libraryPathFromEnvironment != null) {
-      File file = new File(libraryPathFromEnvironment);
-      if (!file.exists())
-        throw new RuntimeException(
-            "Environment variable CUVS_JAVA_SO_PATH points to non-existent file: " + libraryPathFromEnvironment);
-      return file;
-    }
-    return loadLibraryFromJar("/libcuvs_java.so");
-  }
-
-  private static File loadLibraryFromJar(String path) throws IOException {
-    if (!path.startsWith("/")) {
-      throw new IllegalArgumentException("The path has to be absolute (start with '/').");
-    }
-    // Obtain filename from path
-    String[] parts = path.split("/");
-    String filename = (parts.length > 1) ? parts[parts.length - 1] : null;
-
-    // Split filename to prefix and suffix (extension)
-    String prefix = "";
-    String suffix = null;
-    if (filename != null) {
-      parts = filename.split("\\.", 2);
-      prefix = parts[0];
-      suffix = (parts.length > 1) ? "." + parts[parts.length - 1] : null;
-    }
-    // Prepare temporary file
-    File temp = File.createTempFile(prefix, suffix);
-    InputStream libraryStream = Util.class.getModule().getResourceAsStream(path); // Util.class.getResourceAsStream(path);
-    streamCopy(libraryStream, new FileOutputStream(temp));
-
-    return temp;
-  }
-
-  private static void streamCopy(InputStream is, OutputStream os) throws LibraryException {
-    if (is == null) {
-      throw new LibraryException("CuVS Library Not Found in ClassPath");
-    }
-    byte[] buffer = new byte[1024];
-    int readBytes;
-
-    try {
-      while ((readBytes = is.read(buffer)) != -1) {
-        os.write(buffer, 0, readBytes);
-      }
-    } catch (IOException e) {
-      throw new LibraryException(e);
-    } finally {
-      // If read/write fails, close streams safely before throwing an exception
-      if (os != null)
-        try {
-          os.close();
-        } catch (IOException e) {
-          e.printStackTrace();
-        }
-      if (is != null)
-        try {
-          is.close();
-        } catch (IOException e) {
-          e.printStackTrace();
-        }
-    }
   }
 }


### PR DESCRIPTION
This change refactors the native downcall method handles so that they are static final constants - which optimise better by the JVM. It's also the generally accepted pattern, where the handles are tied to the lifetime of class which effectively mediates access - by virtue of reachability. 

I see two issue in my local environment, which seems to predate this change. 

```
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libcuda.so.1+0x236ac0]
C  [libcuda.so.1+0x2d4c0a]
C  [libcuda.so.1+0xd61592]
C  [libcuda.so.1+0x1db2bc]
C  [libcuda.so.1+0x1db70a]
C  [libcuda.so.1+0x1dd535]
C  [libcuda.so.1+0x335e3a]
C  [libcudart.so.12+0x48407]
C  [libcudart.so.12+0x19c42]
C  [libcudart.so.12+0x5c22a]  cudaMemcpy2DAsync_ptsz+0x25a
C  [libcuvs.so+0x21f75ad]  void cuvs::neighbors::cagra::detail::serialize_to_hnswlib<float, unsigned int>(raft::resources const&, std::ostream&, cuvs::neighbors::cagra::index<float, unsigned int> const&)+0x465
C  [libcuvs.so+0x21f81e9]  void cuvs::neighbors::cagra::detail::serialize_to_hnswlib<float, unsigned int>(raft::resources const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cuvs::neighbors::cagra::index<float, unsigned int> const&)+0x41a
C  [libcuvs.so+0x21f4abe]  cuvs::neighbors::cagra::serialize_to_hnswlib(raft::resources const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cuvs::neighbors::cagra::index<float, unsigned int> const&)+0x2f
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
v  ~RuntimeStub::nep_invoker_blob 0x000072e3dc2b0a84
j  java.lang.invoke.LambdaForm$MH+0x000000001e19ec00.invoke(Ljava/lang/Object;JJJJJ)V+16 java.base@22.0.2
j  java.lang.invoke.LambdaForm$MH+0x000000001e1aa000.invokeExact_MT(Ljava/lang/Object;JJJJJLjava/lang/Object;)V+27 java.base@22.0.2
j  jdk.internal.foreign.abi.DowncallStub+0x000000001e19f000.invoke(Ljava/lang/foreign/SegmentAllocator;Ljava/lang/foreign/MemorySegment;Ljava/lang/foreign/MemorySegment;Ljava/lang/foreign/MemorySegment;Ljava/lang/foreign/MemorySegment;Ljava/lang/foreign/MemorySegment;)V+243 java.base@22.0.2
j  java.lang.invoke.LambdaForm$DMH+0x000000001e19f400.invokeStatic(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V+20 java.base@22.0.2
j  java.lang.invoke.LambdaForm$MH+0x000000001e1a1000.invoke(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V+53 java.base@22.0.2
j  java.lang.invoke.LambdaForm$MH+0x000000001e1a9800.invokeExact_MT(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V+24 java.base@22.0.2
j  com.nvidia.cuvs.CagraIndex.serializeToHNSW(Ljava/io/OutputStream;Ljava/io/File;I)V+53 com.nvidia.cuvs
j  com.nvidia.cuvs.CagraIndex.serializeToHNSW(Ljava/io/OutputStream;)V+16 com.nvidia.cuvs
...
```


```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.251 s <<< FAILURE! -- in com.nvidia.cuvs.CagraRandomizedTest
[ERROR] com.nvidia.cuvs.CagraRandomizedTest.testResultsTopKWithRandomValues -- Time elapsed: 1.251 s <<< FAILURE!
java.lang.AssertionError: TopK mismatch for query. expected:<61> but was:<1>
	at __randomizedtesting.SeedInfo.seed([A51D23C3A666747:237D0EA464359907]:0)
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at com.nvidia.cuvs/com.nvidia.cuvs.CuVSTestCase.compareResults(CuVSTestCase.java:73)
	at com.nvidia.cuvs/com.nvidia.cuvs.CagraRandomizedTest.tmpResultsTopKWithRandomValues(CagraRandomizedTest.java:98)
	at com.nvidia.cuvs/com.nvidia.cuvs.CagraRandomizedTest.testResultsTopKWithRandomValues(CagraRandomizedTest.java:29)
...
```